### PR TITLE
Fixed issue #91 with !uninitialized must be true

### DIFF
--- a/src/main/java/org/sentrysoftware/jawk/backend/AVM.java
+++ b/src/main/java/org/sentrysoftware/jawk/backend/AVM.java
@@ -482,7 +482,7 @@ public class AVM implements AwkInterpreter, VariableManager {
 						} else if (o instanceof String) {
 							result = (o.toString().length() > 0);
 						} else if (o instanceof UninitializedObject) {
-							result = true;
+							result = false;
 						} else {
 							throw new Error("Unknown operand_stack type: "+o.getClass()+" for value "+o);
 						}

--- a/src/test/java/org/sentrysoftware/jawk/AwkParserTest.java
+++ b/src/test/java/org/sentrysoftware/jawk/AwkParserTest.java
@@ -62,9 +62,10 @@ public class AwkParserTest {
 	}
 
 	@Test
-	public void testParseGron() throws Exception {
+	public void testGron() throws Exception {
 		String gron = AwkTestHelper.readResource("/xonixx/gron.awk");
 		assertEquals("gron.awk must not trigger any parser exception", "json=[]\n", runAwk(gron, "[]"));
+		assertEquals("gron.awk must work", "json=[]\njson[0]={}\njson[0].a=1\njson[1]={}\njson[1].b=\"2\"\n", runAwk(gron, "[{\"a\": 1},\n{\"b\": \"2\"}]"));
 	}
 
 	@Test

--- a/src/test/java/org/sentrysoftware/jawk/AwkTest.java
+++ b/src/test/java/org/sentrysoftware/jawk/AwkTest.java
@@ -1,6 +1,8 @@
 package org.sentrysoftware.jawk;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.sentrysoftware.jawk.AwkTestHelper.evalAwk;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -13,7 +15,6 @@ import java.util.Collections;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemOutRule;
-import org.sentrysoftware.jawk.Main;
 
 public class AwkTest {
 
@@ -194,5 +195,18 @@ public class AwkTest {
 		awk("//{i=1; j=\"1\"; v[j] = 100; print v[i] v[j];}",
 				pathTo("inventory-shipped"));
 		assertArrayEquals(monotoneArray("100100", 17), linesOutput());
+	}
+	
+	@Test
+	public void testNot() throws Exception {
+		assertEquals("!0 must return 1", "1", evalAwk("!0"));
+		assertEquals("!1 must return 0", "0", evalAwk("!1"));
+		assertEquals("!0.0 must return 1", "1", evalAwk("!0.0"));
+		assertEquals("!0.1 must return 0", "0", evalAwk("!0.1"));
+		assertEquals("!2^31 must return 0", "0", evalAwk("!2^31"));
+		assertEquals("!2^33 must return 0", "0", evalAwk("!2^33"));
+		assertEquals("!\"\" must return 1", "1", evalAwk("!\"\""));
+		assertEquals("!\"a\" must return 0", "0", evalAwk("!\"a\""));
+		assertEquals("!uninitialized must return true", "1", evalAwk("!uninitialized"));
 	}
 }


### PR DESCRIPTION
As reported by @xonixx, `!uninitialized` must return `true` (1)! 😱