### PR TITLE
Fixed arguments order in extension functions calls

### DIFF
--- a/src/main/java/org/sentrysoftware/jawk/backend/AVM.java
+++ b/src/main/java/org/sentrysoftware/jawk/backend/AVM.java
@@ -1954,7 +1954,7 @@ public class AVM implements AwkInterpreter, VariableManager {
 						}
 
 						Object[] args = new Object[(int) num_args];
-						for (int i = 0; i < num_args; ++i) {
+						for (int i = (int)num_args - 1 ; i >=0 ; i--) {
 							args[i] = pop();
 						}
 

--- a/src/test/java/org/sentrysoftware/jawk/ExtensionTest.java
+++ b/src/test/java/org/sentrysoftware/jawk/ExtensionTest.java
@@ -1,0 +1,72 @@
+package org.sentrysoftware.jawk;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.sentrysoftware.jawk.backend.AVM;
+import org.sentrysoftware.jawk.frontend.AwkParser;
+import org.sentrysoftware.jawk.frontend.AwkSyntaxTree;
+import org.sentrysoftware.jawk.intermediate.AwkTuples;
+import org.sentrysoftware.jawk.util.AwkSettings;
+import org.sentrysoftware.jawk.util.ScriptSource;
+import org.sentrysoftware.jawk.ext.JawkExtension;
+
+public class ExtensionTest {
+
+	@Test
+	public void testExtension() throws Exception {
+		
+		JawkExtension myExtension = new TestExtension();
+		Map<String, JawkExtension> myExtensionMap = Arrays.stream(myExtension.extensionKeywords())
+				.collect(Collectors.toMap(k -> k, k -> myExtension));
+		
+		AwkSettings settings = new AwkSettings();
+		
+		// We force \n as the Record Separator (RS) because even if running on Windows
+		// we're passing Java strings, where end of lines are simple \n
+		settings.setDefaultRS("\n");
+		settings.setDefaultORS("\n");
+		
+		// Create the OutputStream, to collect the result as a String
+		ByteArrayOutputStream resultBytesStream = new ByteArrayOutputStream();
+		settings.setOutputStream(new PrintStream(resultBytesStream));
+		
+		// Sets the AWK script to execute
+		settings.addScriptSource(new ScriptSource("Body", new StringReader("BEGIN { ab[1] = \"a\"; ab[2] = \"b\"; printf myExtensionFunction(3, ab) }"), false));
+		
+		// Execute the awk script against the specified input
+		AVM avm = null;
+		try {
+			AwkParser parser = new AwkParser(false, false, myExtensionMap);
+			AwkSyntaxTree ast = parser.parse(settings.getScriptSources());
+			ast.semanticAnalysis();
+			ast.semanticAnalysis();
+			AwkTuples tuples = new AwkTuples();
+			ast.populateTuples(tuples);
+			tuples.postProcess();
+			parser.populateGlobalVariableNameToOffsetMappings(tuples);
+			avm = new AVM(settings, myExtensionMap);
+			avm.interpret(tuples);
+
+		} catch (ExitException e) {
+			if (e.getCode() != 0) {
+				throw e;
+			}
+		} finally {
+			if (avm != null) {
+				avm.waitForIO();
+			}
+		}
+		String resultString = resultBytesStream.toString("UTF-8");
+		assertEquals("ababab", resultString);
+
+	}
+
+}

--- a/src/test/java/org/sentrysoftware/jawk/TestExtension.java
+++ b/src/test/java/org/sentrysoftware/jawk/TestExtension.java
@@ -1,0 +1,54 @@
+package org.sentrysoftware.jawk;
+
+import org.sentrysoftware.jawk.ext.AbstractExtension;
+import org.sentrysoftware.jawk.ext.JawkExtension;
+import org.sentrysoftware.jawk.jrt.AssocArray;
+import org.sentrysoftware.jawk.jrt.JRT;
+import org.sentrysoftware.jawk.jrt.VariableManager;
+import org.sentrysoftware.jawk.util.AwkSettings;
+
+public class TestExtension extends AbstractExtension implements JawkExtension {
+
+	private static final String MY_EXTENSION_FUNCTION = "myExtensionFunction";
+
+	@Override
+	public void init(VariableManager vm, JRT jrt, AwkSettings settings) {
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "TestExtension";
+	}
+
+	@Override
+	public String[] extensionKeywords() {
+		return new String[] { MY_EXTENSION_FUNCTION };
+	}
+
+	@Override
+	public int[] getAssocArrayParameterPositions(String extensionKeyword, int numArgs) {
+		if (MY_EXTENSION_FUNCTION.equals(extensionKeyword)) {
+			return new int[] { 1 };
+		} else {
+			return new int[] {};
+		}
+	}
+
+	@Override
+	public Object invoke(String keyword, Object[] args) {
+		if (MY_EXTENSION_FUNCTION.equals(keyword)) {
+			StringBuilder result = new StringBuilder();
+			int count = ((Long)args[0]).intValue();
+			AssocArray array = (AssocArray)args[1];
+			for (int i = 0 ; i < count ; i++) {
+				for (Object item : array.keySet()) {
+					result.append((String)array.get(item));
+				}
+			}
+			return result.toString();
+		} else {
+			throw new NotImplementedError(keyword + " is not implemented by " + getExtensionName());
+		}
+	}
+
+}


### PR DESCRIPTION
Arguments were passed in reserved order by the AVM to the `invoke(keyword, args)` method of the `JawkExtension` instance.