### PR TITLE
Fix return assignment in RuntimeStack.setVariable

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/RuntimeStack.java
+++ b/src/main/java/org/metricshub/jawk/backend/RuntimeStack.java
@@ -97,9 +97,11 @@ class RuntimeStack {
 		assert globals != null;
 		assert offset != AVM.NULL_OFFSET;
 		if (isGlobal) {
-			return globals[(int) offset] = val;
+			globals[(int) offset] = val;
+			return val;
 		} else {
-			return locals[(int) offset] = val;
+			locals[(int) offset] = val;
+			return val;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- fix RuntimeStack.setVariable so assignments and returns occur separately
- run Maven license header update and formatter

## Testing
- `mvn verify site --offline`

------
https://chatgpt.com/codex/tasks/task_b_683da5c6bbc8832183076df5e85cd9ff