### PR TITLE
Refactor parser to limit checkstyle suppression

### DIFF
--- a/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
+++ b/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
@@ -889,6 +889,7 @@ public class AwkParser {
 	}
 
 	// RECURSIVE DECENT PARSER:
+	// CHECKSTYLE:OFF MethodName
 	// SCRIPT : \n [RULE_LIST] EOF
 	AST SCRIPT() throws IOException {
 		AST rl;
@@ -2063,6 +2064,8 @@ public class AwkParser {
 		expectKeyword("continue");
 		return new ContinueStatement_AST();
 	}
+
+	// CHECKSTYLE:ON MethodName
 
 	private void expectKeyword(String keyword) throws IOException {
 		if (token == KEYWORDS.get(keyword)) {


### PR DESCRIPTION
## Summary
- restore AwkParser grammar methods
- restrict checkstyle ignore to only the MethodName rule

## Testing
- `mvn --offline test`
- `mvn --offline verify`


------
https://chatgpt.com/codex/tasks/task_b_683da5ca22e88321bff5125c48f54040