### PR TITLE
Handle exit code for bwk t scripts

### DIFF
--- a/src/test/java/org/metricshub/jawk/BwkTTest.java
+++ b/src/test/java/org/metricshub/jawk/BwkTTest.java
@@ -85,9 +85,17 @@ public class BwkTTest {
 		// Get the input file (always the same)
 		File inputFile = new File(bwkTDirectory, "inputs/test.data");
 
-		String result = AwkTestHelper.runAwk(awkFile, inputFile);
+		AwkTestHelper.RunResult rr = AwkTestHelper.runAwkWithExitCode(awkFile, inputFile);
 		String expectedResult = AwkTestHelper.readTextFile(okFile);
-		assertEquals(expectedResult, result);
+		assertEquals(expectedResult, rr.output);
+
+		int expectedCode = 0;
+		if ("t.exit".equals(awkName)) {
+			expectedCode = 1;
+		} else if ("t.exit1".equals(awkName)) {
+			expectedCode = 2;
+		}
+		assertEquals("Unexpected exit code for " + awkName, expectedCode, rr.exitCode);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- return exit code when running Awk scripts in tests
- verify expected exit code for `t.exit` and `t.exit1`

## Testing
- `mvn --offline formatter:format`
- `mvn --offline verify`

------
https://chatgpt.com/codex/tasks/task_b_6840507e90608321ab70b3cb3857dd62