### PR TITLE
Fix dynamic field number handling

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.io.StringReader;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -238,19 +239,28 @@ public class AVM implements AwkInterpreter, VariableManager {
 	private Set<String> functionNames;
 
 	private static int parseIntField(Object obj, PositionForInterpretation position) {
-		int fieldVal;
-
 		if (obj instanceof Number) {
-			fieldVal = ((Number) obj).intValue();
-		} else {
-			try {
-				fieldVal = (int) Double.parseDouble(obj.toString());
-			} catch (NumberFormatException nfe) {
+			double num = ((Number) obj).doubleValue();
+			if (num < 0) {
 				throw new AwkRuntimeException(position.lineNumber(), "Field $(" + obj.toString() + ") is incorrect.");
 			}
+			return (int) num;
 		}
 
-		return fieldVal;
+		String str = obj.toString();
+		if (str.isEmpty()) {
+			return 0;
+		}
+
+		try {
+			double num = new BigDecimal(str).doubleValue();
+			if (num < 0) {
+				throw new AwkRuntimeException(position.lineNumber(), "Field $(" + obj.toString() + ") is incorrect.");
+			}
+			return (int) num;
+		} catch (NumberFormatException nfe) {
+			return 0;
+		}
 	}
 
 	private void setNumOnJRT(int fieldNum, double num) {

--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -797,17 +797,28 @@ public class JRT {
 	}
 
 	private static int toFieldNumber(Object o) {
-		int fieldnum;
 		if (o instanceof Number) {
-			fieldnum = ((Number) o).intValue();
-		} else {
-			try {
-				fieldnum = (int) Double.parseDouble(o.toString());
-			} catch (NumberFormatException nfe) {
+			double num = ((Number) o).doubleValue();
+			if (num < 0) {
 				throw new RuntimeException("Field $(" + o.toString() + ") is incorrect.");
 			}
+			return (int) num;
 		}
-		return fieldnum;
+
+		String str = o.toString();
+		if (str.isEmpty()) {
+			return 0;
+		}
+
+		try {
+			double num = new BigDecimal(str).doubleValue();
+			if (num < 0) {
+				throw new RuntimeException("Field $(" + o.toString() + ") is incorrect.");
+			}
+			return (int) num;
+		} catch (NumberFormatException nfe) {
+			return 0;
+		}
 	}
 
 	/**

--- a/src/test/java/org/metricshub/jawk/DynamicFieldTest.java
+++ b/src/test/java/org/metricshub/jawk/DynamicFieldTest.java
@@ -1,0 +1,60 @@
+package org.metricshub.jawk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.metricshub.jawk.AwkTestHelper.runAwk;
+
+import org.junit.Test;
+import org.metricshub.jawk.jrt.AwkRuntimeException;
+
+public class DynamicFieldTest {
+
+	@Test
+	public void testEmptyStringFieldIndex() throws Exception {
+		String result = runAwk("BEGIN{idx=\"\"}{print $(idx)}", "a b c");
+		assertEquals("a b c\n", result);
+	}
+
+	@Test
+	public void testNonNumericFieldIndex() throws Exception {
+		String result = runAwk("BEGIN{idx=\"foo\"}{print $(idx)}", "a b");
+		assertEquals("a b\n", result);
+	}
+
+	@Test
+	public void testUninitializedVariableFieldIndex() throws Exception {
+		String result = runAwk("{print $(idx)}", "a b");
+		assertEquals("a b\n", result);
+	}
+
+	@Test
+	public void testNumericStringFieldIndex() throws Exception {
+		String result = runAwk("BEGIN{idx=\"2\"}{print $(idx)}", "a b c");
+		assertEquals("b\n", result);
+	}
+
+	@Test
+	public void testFloatStringFieldIndex() throws Exception {
+		String result = runAwk("BEGIN{idx=\"2.7\"}{print $(idx)}", "a b c");
+		assertEquals("b\n", result);
+	}
+
+	@Test
+	public void testFloatVariableFieldIndex() throws Exception {
+		String result = runAwk("BEGIN{idx=2.3}{print $(idx)}", "a b c");
+		assertEquals("b\n", result);
+	}
+
+	@Test
+	public void testExponentStringFieldIndex() throws Exception {
+		String result = runAwk("BEGIN{idx=\"3e0\"}{print $(idx)}", "1 2 3 4");
+		assertEquals("3\n", result);
+	}
+
+	@Test
+	public void testNegativeFieldIndex() {
+		assertThrows(
+				AwkRuntimeException.class,
+				() -> runAwk("BEGIN{idx=-1}{print $(idx)}", "a b"));
+	}
+}


### PR DESCRIPTION
## Summary
- allow dynamic field index expressions that resolve to empty or non-numeric values
- treat negative field numbers as an error
- keep behaviour consistent in runtime and VM helper
- add extra unit tests for dynamic field access

## Testing
- `mvn test --offline`
- `mvn --offline verify site -DskipTests=false`


------
https://chatgpt.com/codex/tasks/task_b_684050544d5c8321a83e7a3357bc34cb