### PR TITLE
refactor: extract tuple helpers

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -46,7 +46,7 @@ import org.metricshub.jawk.ext.JawkExtension;
 import org.metricshub.jawk.frontend.AstNode;
 import org.metricshub.jawk.intermediate.Address;
 import org.metricshub.jawk.intermediate.AwkTuples;
-import org.metricshub.jawk.intermediate.Position;
+import org.metricshub.jawk.intermediate.PositionTracker;
 import org.metricshub.jawk.intermediate.UninitializedObject;
 import org.metricshub.jawk.jrt.AssocArray;
 import org.metricshub.jawk.jrt.AwkRuntimeException;
@@ -270,7 +270,7 @@ public class AVM implements VariableManager {
 		return operandStack.size() == 0 ? null : pop();
 	}
 
-	private static int parseIntField(Object obj, Position position) {
+	private static int parseIntField(Object obj, PositionTracker position) {
 		if (obj instanceof Number) {
 			double num = ((Number) obj).doubleValue();
 			if (num < 0) {
@@ -312,7 +312,7 @@ public class AVM implements VariableManager {
 		}
 	}
 
-	private String execSubOrGSub(Position position, int gsubArgPos) {
+	private String execSubOrGSub(PositionTracker position, int gsubArgPos) {
 		String newString;
 
 		// arg[gsubArgPos] = isGsub
@@ -347,7 +347,7 @@ public class AVM implements VariableManager {
 		globalVariableArrays = tuples.getGlobalVariableAarrayMap();
 		functionNames = tuples.getFunctionNameSet();
 
-		Position position = (Position) tuples.top();
+		PositionTracker position = tuples.top();
 
 		try {
 			while (!position.isEOF()) {
@@ -2238,7 +2238,7 @@ public class AVM implements VariableManager {
 	/**
 	 * Awk variable assignment functionality.
 	 */
-	private void assign(long l, Object value, boolean isGlobal, Position position) {
+	private void assign(long l, Object value, boolean isGlobal, PositionTracker position) {
 		// check if curr value already refers to an array
 		if (runtimeStack.getVariable(l, isGlobal) instanceof AssocArray) {
 			throw new AwkRuntimeException(position.lineNumber(), "cannot assign anything to an unindexed associative array");

--- a/src/main/java/org/metricshub/jawk/intermediate/AddressManager.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/AddressManager.java
@@ -1,0 +1,69 @@
+package org.metricshub.jawk.intermediate;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Manages creation and resolution of {@link Address} instances for
+ * {@link AwkTuples}.
+ */
+class AddressManager implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Set<Address> unresolvedAddresses = new HashSet<Address>();
+	private final Map<Integer, Address> addressIndexes = new HashMap<Integer, Address>();
+	private final Map<String, Integer> addressLabelCounts = new HashMap<String, Integer>();
+
+	Address createAddress(String label) {
+		Integer count = addressLabelCounts.get(label);
+		if (count == null) {
+			count = 0;
+		} else {
+			count = count + 1;
+		}
+		addressLabelCounts.put(label, count);
+		Address address = new Address(label + "_" + count);
+		unresolvedAddresses.add(address);
+		return address;
+	}
+
+	void resolveAddress(Address address, int index) {
+		if (unresolvedAddresses.contains(address)) {
+			unresolvedAddresses.remove(address);
+			address.assignIndex(index);
+			addressIndexes.put(index, address);
+		} else {
+			throw new Error(address.toString() + " is already resolved, or unresolved from another scope.");
+		}
+	}
+
+	Address getAddress(int index) {
+		return addressIndexes.get(index);
+	}
+}

--- a/src/main/java/org/metricshub/jawk/intermediate/PositionTracker.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/PositionTracker.java
@@ -29,14 +29,14 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  *
  * @author Danny Daglas
  */
-public class Position {
+public class PositionTracker {
 
 	private int idx = 0;
 	private final java.util.List<Tuple> queue;
 	private Tuple tuple;
 
-	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Position must iterate over the shared tuple list")
-	public Position(java.util.List<Tuple> queue) {
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "PositionTracker must iterate over the shared tuple list")
+	public PositionTracker(java.util.List<Tuple> queue) {
 		this.queue = queue;
 		this.tuple = queue.isEmpty() ? null : queue.get(idx);
 	}


### PR DESCRIPTION
## Summary
- introduce dedicated AddressManager and PositionTracker classes
- simplify AwkTuples by delegating address and position logic
- update AVM to use PositionTracker

## Testing
- `mvn test`
- `mvn verify site`


------
https://chatgpt.com/codex/tasks/task_b_68b1b991d7048321a5ab168a74e0e79d