### PR TITLE
Restore CRLF expectations in Windows JRT tests

### DIFF
--- a/src/test/java/org/metricshub/jawk/JRTTest.java
+++ b/src/test/java/org/metricshub/jawk/JRTTest.java
@@ -124,7 +124,7 @@ public class JRTTest {
 		AwkTestSupport
 				.awkTest("more process")
 				.script("BEGIN { print \"Hello\" | \"more\"; close(\"more\") }")
-				.expectLines("Hello", "")
+				.expect("Hello\r\n\r\n")
 				.runAndAssert();
 	}
 
@@ -144,7 +144,7 @@ public class JRTTest {
 		AwkTestSupport
 				.awkTest("system pipe windows")
 				.script("BEGIN { print(system(\"echo test|findstr test\")) }")
-				.expectLines("test", "0")
+				.expect("test\r\n0\n")
 				.runAndAssert();
 	}
 


### PR DESCRIPTION
## Summary
- restore explicit CRLF expectations for the Windows `more` pipe integration test
- ensure the Windows `findstr` system pipe test keeps its carriage returns in the expected output

## Testing
- mvn -Dtest=JRTTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915050541a48321ac199a7a4bf2dafa)