### PR TITLE
Simplify Awk builder override

### DIFF
--- a/src/test/java/org/metricshub/jawk/ExtensionTest.java
+++ b/src/test/java/org/metricshub/jawk/ExtensionTest.java
@@ -1,20 +1,12 @@
 package org.metricshub.jawk;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.StringReader;
-import java.util.Collections;
 import org.junit.Test;
-import org.metricshub.jawk.ExitException;
-import org.metricshub.jawk.intermediate.AwkTuples;
+import org.metricshub.jawk.AwkTestSupport.TestResult;
 import org.metricshub.jawk.jrt.AwkRuntimeException;
 import org.metricshub.jawk.jrt.IllegalAwkArgumentException;
-import org.metricshub.jawk.util.AwkSettings;
-import org.metricshub.jawk.util.ScriptSource;
 
 /**
  * Tests the integration of a custom {@link JawkExtension} implementation with
@@ -28,118 +20,63 @@ public class ExtensionTest {
 	 */
 	@Test
 	public void testExtension() throws Exception {
-		Awk awk = new Awk(new TestExtension());
-		AwkSettings settings = new AwkSettings();
-
-		// We force \n as the Record Separator (RS) because even if running on Windows
-		// we're passing Java strings, where end of lines are simple \n
-		settings.setDefaultRS("\n");
-		settings.setDefaultORS("\n");
-
-		// Create the OutputStream, to collect the result as a String
-		ByteArrayOutputStream resultBytesStream = new ByteArrayOutputStream();
-		settings.setOutputStream(new PrintStream(resultBytesStream));
-
-		ScriptSource script = new ScriptSource(
-				"Body",
-				new StringReader(
-						"BEGIN { ab[1] = \"a\"; ab[2] = \"b\"; printf myExtensionFunction(3, ab) }"));
-
-		AwkTuples tuples = awk.compile(Collections.singletonList(script));
-		try {
-			awk.invoke(tuples, settings);
-		} catch (ExitException e) {
-			if (e.getCode() != 0) {
-				throw e;
-			}
-		}
-		String resultString = resultBytesStream.toString("UTF-8");
-		assertEquals("ababab", resultString);
+		AwkTestSupport
+				.awkTest("extension invocation")
+				.script("BEGIN { ab[1] = \"a\"; ab[2] = \"b\"; printf myExtensionFunction(3, ab) }")
+				.withExtensions(new TestExtension())
+				.expect("ababab")
+				.runAndAssert();
 	}
 
-	@Test(expected = IllegalAwkArgumentException.class)
+	@Test
 	public void testAnnotatedExtensionArgumentValidation() throws Exception {
-		Awk awk = new Awk(new TestExtension());
-		AwkSettings settings = new AwkSettings();
-
-		settings.setDefaultRS("\n");
-		settings.setDefaultORS("\n");
-
-		ScriptSource script = new ScriptSource(
-				"Body",
-				new StringReader("BEGIN { myExtensionFunction() }"));
-
-		awk.compile(Collections.singletonList(script));
+		AwkTestSupport
+				.awkTest("annotated extension argument validation")
+				.script("BEGIN { myExtensionFunction() }")
+				.withExtensions(new TestExtension())
+				.expectThrow(IllegalAwkArgumentException.class)
+				.runAndAssert();
 	}
 
 	@Test
 	public void testVarArgAssocArrayInvocation() throws Exception {
-		Awk awk = new Awk(new TestExtension());
-		AwkSettings settings = new AwkSettings();
-
-		settings.setDefaultRS("\n");
-		settings.setDefaultORS("\n");
-
-		ByteArrayOutputStream resultBytesStream = new ByteArrayOutputStream();
-		settings.setOutputStream(new PrintStream(resultBytesStream));
-
-		ScriptSource script = new ScriptSource(
-				"Body",
-				new StringReader(
-						"BEGIN { first[1] = 1; second[1] = 2; print varArgAssoc(first, second) }"));
-
-		AwkTuples tuples = awk.compile(Collections.singletonList(script));
-		try {
-			awk.invoke(tuples, settings);
-		} catch (ExitException e) {
-			if (e.getCode() != 0) {
-				throw e;
-			}
-		}
-		assertEquals("2\n", resultBytesStream.toString("UTF-8"));
+		AwkTestSupport
+				.awkTest("var arg assoc array invocation")
+				.script("BEGIN { first[1] = 1; second[1] = 2; print varArgAssoc(first, second) }")
+				.withExtensions(new TestExtension())
+				.expectLines("2")
+				.runAndAssert();
 	}
 
 	@Test
 	public void testVarArgAssocArraySemanticValidation() throws Exception {
-		Awk awk = new Awk(new TestExtension());
-		AwkSettings settings = new AwkSettings();
-
-		settings.setDefaultRS("\n");
-		settings.setDefaultORS("\n");
-
-		ScriptSource script = new ScriptSource(
-				"Body",
-				new StringReader(
-						"BEGIN { array[1] = 1; scalar = 1; print varArgAssoc(array, scalar) }"));
-
-		try {
-			awk.compile(Collections.singletonList(script));
-			fail("Expected a compile-time failure for scalar argument");
-		} catch (RuntimeException ex) {
-			assertTrue(ex.getMessage().contains("associative array"));
-		}
+		TestResult result = AwkTestSupport
+				.awkTest("var arg assoc array semantic validation")
+				.script("BEGIN { array[1] = 1; scalar = 1; print varArgAssoc(array, scalar) }")
+				.withExtensions(new TestExtension())
+				.expectThrow(RuntimeException.class)
+				.run();
+		result.assertExpected();
+		assertTrue(result.thrownException().getMessage().contains("associative array"));
 	}
 
 	@Test
 	public void testVarArgAssocArrayRuntimeValidation() throws Exception {
-		Awk awk = new Awk(new TestExtension());
-		AwkSettings settings = new AwkSettings();
-
-		settings.setDefaultRS("\n");
-		settings.setDefaultORS("\n");
-
-		ScriptSource script = new ScriptSource(
-				"Body",
-				new StringReader("BEGIN { array[1] = 1; print varArgAssoc(array, 1) }"));
-
-		AwkTuples tuples = awk.compile(Collections.singletonList(script));
-		try {
-			awk.invoke(tuples, settings);
-			fail("Expected IllegalAwkArgumentException for non-array argument");
-		} catch (IllegalAwkArgumentException ex) {
-// expected
-		} catch (AwkRuntimeException ex) {
-			assertTrue(ex.getCause() instanceof IllegalAwkArgumentException);
+		TestResult result = AwkTestSupport
+				.awkTest("var arg assoc array runtime validation")
+				.script("BEGIN { array[1] = 1; print varArgAssoc(array, 1) }")
+				.withExtensions(new TestExtension())
+				.expectThrow(RuntimeException.class)
+				.run();
+		result.assertExpected();
+		Throwable thrown = result.thrownException();
+		if (thrown instanceof IllegalAwkArgumentException) {
+			return;
 		}
+		if (thrown instanceof AwkRuntimeException) {
+			assertTrue(thrown.getCause() instanceof IllegalAwkArgumentException);
+			return;
+		}
+		fail("Expected IllegalAwkArgumentException but got " + thrown.getClass().getName());
 	}
 }


### PR DESCRIPTION
## Summary
- simplify `AwkTestSupport` so tests register a fully-initialized `Awk` instance through `withAwk(...)`
- keep the extension-based construction logic untouched while removing the unused supplier wiring

## Testing
- mvn -Dtest=ExtensionTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69150a4895308321802c26cb19945878)