### PR TITLE
Replace generic PUSH opcode with type-specialized PUSH_LONG, PUSH_DOUBLE, PUSH_STRING

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -668,9 +668,21 @@ public class AVM implements VariableManager, Closeable {
 					position.next();
 					break;
 				}
-				case PUSH: {
-					// arg[0] = constant to push onto the stack
-					push(position.arg(0));
+				case PUSH_LONG: {
+					// arg[0] = long constant to push onto the stack
+					push(position.intArg(0));
+					position.next();
+					break;
+				}
+				case PUSH_DOUBLE: {
+					// arg[0] = double constant to push onto the stack
+					push(position.doubleArg(0));
+					position.next();
+					break;
+				}
+				case PUSH_STRING: {
+					// arg[0] = string constant to push onto the stack
+					push(position.stringArg(0));
 					position.next();
 					break;
 				}

--- a/src/main/java/org/metricshub/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/AwkTuples.java
@@ -114,13 +114,13 @@ public class AwkTuples implements Serializable {
 	 */
 	public void push(Object o) {
 		if (o instanceof String) {
-			queue.add(new Tuple(Opcode.PUSH, o.toString()));
+			queue.add(new Tuple(Opcode.PUSH_STRING, o.toString()));
 		} else if (o instanceof Integer) {
-			queue.add(new Tuple(Opcode.PUSH, (Integer) o));
+			queue.add(new Tuple(Opcode.PUSH_LONG, (long) (Integer) o));
 		} else if (o instanceof Long) {
-			queue.add(new Tuple(Opcode.PUSH, (Long) o));
+			queue.add(new Tuple(Opcode.PUSH_LONG, (long) (Long) o));
 		} else if (o instanceof Double) {
-			queue.add(new Tuple(Opcode.PUSH, (Double) o));
+			queue.add(new Tuple(Opcode.PUSH_DOUBLE, (Double) o));
 		}
 	}
 
@@ -1828,23 +1828,16 @@ public class AwkTuples implements Serializable {
 	}
 
 	private Object literalValue(Tuple tuple) {
-		if (tuple.getOpcode() != Opcode.PUSH) {
-			return null;
-		}
-		Class<?>[] types = tuple.getTypes();
-		if (types.length == 0 || types[0] == null) {
-			return null;
-		}
-		if (types[0] == Long.class) {
+		switch (tuple.getOpcode()) {
+		case PUSH_LONG:
 			return Long.valueOf(tuple.getInts()[0]);
-		}
-		if (types[0] == Double.class) {
+		case PUSH_DOUBLE:
 			return Double.valueOf(tuple.getDoubles()[0]);
-		}
-		if (types[0] == String.class) {
+		case PUSH_STRING:
 			return tuple.getStrings()[0];
+		default:
+			return null;
 		}
-		return null;
 	}
 
 	private Object foldBinary(Object left, Object right, Tuple operation) {
@@ -1952,20 +1945,20 @@ public class AwkTuples implements Serializable {
 	private Tuple createLiteralPush(Object value, int lineNumber) {
 		Tuple tuple;
 		if (value instanceof Long) {
-			tuple = new Tuple(Opcode.PUSH, ((Long) value).longValue());
+			tuple = new Tuple(Opcode.PUSH_LONG, ((Long) value).longValue());
 		} else if (value instanceof Integer) {
-			tuple = new Tuple(Opcode.PUSH, ((Integer) value).longValue());
+			tuple = new Tuple(Opcode.PUSH_LONG, ((Integer) value).longValue());
 		} else if (value instanceof Double) {
-			tuple = new Tuple(Opcode.PUSH, ((Double) value).doubleValue());
+			tuple = new Tuple(Opcode.PUSH_DOUBLE, ((Double) value).doubleValue());
 		} else if (value instanceof Number) {
 			double d = ((Number) value).doubleValue();
 			if (JRT.isActuallyLong(d)) {
-				tuple = new Tuple(Opcode.PUSH, (long) Math.rint(d));
+				tuple = new Tuple(Opcode.PUSH_LONG, (long) Math.rint(d));
 			} else {
-				tuple = new Tuple(Opcode.PUSH, d);
+				tuple = new Tuple(Opcode.PUSH_DOUBLE, d);
 			}
 		} else if (value instanceof String) {
-			tuple = new Tuple(Opcode.PUSH, (String) value);
+			tuple = new Tuple(Opcode.PUSH_STRING, (String) value);
 		} else {
 			throw new IllegalArgumentException("Unsupported literal value: " + value);
 		}

--- a/src/main/java/org/metricshub/jawk/intermediate/Opcode.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/Opcode.java
@@ -30,12 +30,29 @@ public enum Opcode {
 	 */
 	POP,
 	/**
-	 * Pushes an item onto the operand stack.
+	 * Pushes a long constant onto the operand stack.
 	 * <p>
+	 * Argument: the long value<br/>
 	 * Stack before: ...<br/>
 	 * Stack after: x ...
 	 */
-	PUSH,
+	PUSH_LONG,
+	/**
+	 * Pushes a double constant onto the operand stack.
+	 * <p>
+	 * Argument: the double value<br/>
+	 * Stack before: ...<br/>
+	 * Stack after: x ...
+	 */
+	PUSH_DOUBLE,
+	/**
+	 * Pushes a string constant onto the operand stack.
+	 * <p>
+	 * Argument: the string value<br/>
+	 * Stack before: ...<br/>
+	 * Stack after: x ...
+	 */
+	PUSH_STRING,
 	/**
 	 * Pops and evaluates the top-of-stack; if
 	 * false, it jumps to a specified address.

--- a/src/main/java/org/metricshub/jawk/intermediate/PositionTracker.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/PositionTracker.java
@@ -66,20 +66,44 @@ public class PositionTracker {
 		return tuple.getOpcode();
 	}
 
+	/**
+	 * Returns the long argument at the specified index without type dispatch.
+	 *
+	 * @param argIdx argument index
+	 * @return the long value
+	 */
 	public long intArg(int argIdx) {
-		Class<?> c = tuple.getTypes()[argIdx];
-		if (c == Long.class) {
-			return tuple.getInts()[argIdx];
-		}
-		throw new Error("Invalid arg type: " + c + ", arg_idx = " + argIdx + ", tuple = " + tuple);
+		return tuple.getInts()[argIdx];
 	}
 
+	/**
+	 * Returns the boolean argument at the specified index without type dispatch.
+	 *
+	 * @param argIdx argument index
+	 * @return the boolean value
+	 */
 	public boolean boolArg(int argIdx) {
-		Class<?> c = tuple.getTypes()[argIdx];
-		if (c == Boolean.class) {
-			return tuple.getBools()[argIdx];
-		}
-		throw new Error("Invalid arg type: " + c + ", arg_idx = " + argIdx + ", tuple = " + tuple);
+		return tuple.getBools()[argIdx];
+	}
+
+	/**
+	 * Returns the string argument at the specified index without type dispatch.
+	 *
+	 * @param argIdx argument index
+	 * @return the string value
+	 */
+	public String stringArg(int argIdx) {
+		return tuple.getStrings()[argIdx];
+	}
+
+	/**
+	 * Returns the double argument at the specified index without type dispatch.
+	 *
+	 * @param argIdx argument index
+	 * @return the double value
+	 */
+	public double doubleArg(int argIdx) {
+		return tuple.getDoubles()[argIdx];
 	}
 
 	public Object arg(int argIdx) {

--- a/src/test/java/org/metricshub/jawk/AwkTupleOptimizationTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkTupleOptimizationTest.java
@@ -367,13 +367,16 @@ public class AwkTupleOptimizationTest {
 				dump.contains("GET_INPUT_FIELD_CONST, " + fieldIndex));
 		assertFalse(
 				"Literal field index should not be pushed separately",
-				dump.contains("PUSH, " + fieldIndex));
+				dump.contains("PUSH_LONG, " + fieldIndex));
 	}
 
 	private static boolean hasLiteralPush(AwkTuples tuples, Object expected) {
 		PositionTracker tracker = tuples.top();
 		while (!tracker.isEOF()) {
-			if (tracker.opcode() == Opcode.PUSH) {
+			Opcode opcode = tracker.opcode();
+			if (opcode == Opcode.PUSH_LONG
+					|| opcode == Opcode.PUSH_DOUBLE
+					|| opcode == Opcode.PUSH_STRING) {
 				Object value = tracker.arg(0);
 				if (expected instanceof Number && value instanceof Number) {
 					double actual = ((Number) value).doubleValue();


### PR DESCRIPTION
## Summary

The generic `PUSH` opcode used a polymorphic `PositionTracker.arg(int)` method that dispatched on the stored type at runtime (checking `Long.class`, `Double.class`, `String.class`, etc.). This added unnecessary overhead for every constant push during execution.

This PR replaces the single `PUSH` opcode with three type-specialized opcodes that bypass the type dispatch entirely.

## Changes

### New opcodes in `Opcode.java`
- **`PUSH_LONG`** — pushes a long constant
- **`PUSH_DOUBLE`** — pushes a double constant
- **`PUSH_STRING`** — pushes a string constant

The generic `PUSH` opcode has been removed.

### Fast typed accessors in `PositionTracker.java`
- Added **`stringArg(int)`** — returns `tuple.getStrings()[argIdx]` directly
- Added **`doubleArg(int)`** — returns `tuple.getDoubles()[argIdx]` directly
- Simplified **`intArg(int)`** and **`boolArg(int)`** — removed the type-checking guard to directly return `tuple.getInts()[argIdx]` and `tuple.getBools()[argIdx]`, consistent with the new accessors

### Compiler changes in `AwkTuples.java`
- `push(Object)` now emits `PUSH_LONG`, `PUSH_DOUBLE`, or `PUSH_STRING`
- `literalValue()` recognizes the new opcodes for constant folding
- `createLiteralPush()` emits specialized opcodes for folded results

### VM changes in `AVM.java`
- `case PUSH_LONG` uses `position.intArg(0)` — no type dispatch
- `case PUSH_DOUBLE` uses `position.doubleArg(0)` — no type dispatch
- `case PUSH_STRING` uses `position.stringArg(0)` — no type dispatch

### Test updates in `AwkTupleOptimizationTest.java`
- `hasLiteralPush()` checks for all three specialized push opcodes
- Dump assertion updated for `PUSH_LONG` format

## Verification

- All 399 unit tests pass
- Zero checkstyle, PMD, and SpotBugs violations