### PR TITLE
Fix #429 allow @JawkAssocArray parameters typed as Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ Awk awk = new Awk();
 String result = awk.run("{ print toupper($0) }", "hello world");
 ```
 
+When writing custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values rather than `AssocArray`.
+
 ## Documentation
 
 - Overview: https://metricshub.org/Jawk/index.html
 - CLI: https://metricshub.org/Jawk/cli.html
 - Java: https://metricshub.org/Jawk/java.html
 - Extensions: https://metricshub.org/Jawk/extensions.html
+- Writing Extensions: https://metricshub.org/Jawk/extensions-writing.html
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Awk awk = new Awk();
 String result = awk.run("{ print toupper($0) }", "hello world");
 ```
 
-When writing custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values rather than `AssocArray`.
+When writing custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values rather than concrete map implementations.
 
 ## Documentation
 

--- a/src/main/java/org/metricshub/jawk/ext/ExtensionFunction.java
+++ b/src/main/java/org/metricshub/jawk/ext/ExtensionFunction.java
@@ -31,11 +31,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.metricshub.jawk.ext.annotations.JawkAssocArray;
 import org.metricshub.jawk.ext.annotations.JawkFunction;
-import org.metricshub.jawk.jrt.AssocArray;
 import org.metricshub.jawk.jrt.IllegalAwkArgumentException;
 
 /**
@@ -124,11 +124,11 @@ public final class ExtensionFunction implements Serializable {
 				if (parameter.isVarArgs()) {
 					parameterType = parameterType.getComponentType();
 				}
-				if (!AssocArray.class.isAssignableFrom(parameterType)) {
+				if (!Map.class.isAssignableFrom(parameterType)) {
 					throw new IllegalStateException(
 							"Parameter " + idx + " of " + methodParam
 									+ " annotated with @" + JawkAssocArray.class.getSimpleName()
-									+ " must accept " + AssocArray.class.getName());
+									+ " must accept " + Map.class.getName());
 				}
 				assoc[idx] = true;
 			}
@@ -336,7 +336,7 @@ public final class ExtensionFunction implements Serializable {
 				continue;
 			}
 			Object argument = args[idx];
-			if (!(argument instanceof AssocArray)) {
+			if (!(argument instanceof Map)) {
 				throw new IllegalAwkArgumentException(
 						"Argument " + idx + " passed to extension function '" + keyword
 								+ "' must be an associative array");
@@ -345,7 +345,7 @@ public final class ExtensionFunction implements Serializable {
 		if (varArgs && varArgAssocArray) {
 			for (int idx = mandatoryParameterCount; idx < argCount; idx++) {
 				Object argument = args[idx];
-				if (!(argument instanceof AssocArray)) {
+				if (!(argument instanceof Map)) {
 					throw new IllegalAwkArgumentException(
 							"Argument " + idx + " passed to extension function '" + keyword
 									+ "' must be an associative array");

--- a/src/main/java/org/metricshub/jawk/ext/ExtensionFunction.java
+++ b/src/main/java/org/metricshub/jawk/ext/ExtensionFunction.java
@@ -116,6 +116,36 @@ public final class ExtensionFunction implements Serializable {
 		return method;
 	}
 
+	/**
+	 * Inspects the declared Java parameters and records which ones are annotated
+	 * with {@link JawkAssocArray}.
+	 * <p>
+	 * The validation is intentionally stricter than checking
+	 * {@code Map.class.isAssignableFrom(parameterType)} alone. Jawk passes runtime
+	 * associative arrays as {@link AssocArray} instances, so the declared parameter
+	 * type must satisfy two constraints:
+	 * </p>
+	 * <ul>
+	 * <li>it must be a {@link Map} type, because {@code @JawkAssocArray} is a
+	 * map-shaped contract for extension authors</li>
+	 * <li>it must also be able to receive an {@link AssocArray} instance at
+	 * invocation time</li>
+	 * </ul>
+	 * <p>
+	 * That second constraint rejects concrete map implementations such as
+	 * {@link java.util.HashMap}. A declaration like
+	 * {@code @JawkAssocArray HashMap<Object, Object>} is map-shaped, but it is not
+	 * compatible with the {@link AssocArray} values that Jawk actually passes, so
+	 * letting it register here would only defer the failure until reflective
+	 * invocation.
+	 * </p>
+	 *
+	 * @param methodParam method whose parameters are being inspected
+	 * @param parameters declared parameters of {@code methodParam}
+	 * @return flags indicating which parameter positions require associative arrays
+	 * @throws IllegalStateException when an annotated parameter cannot receive the
+	 *         runtime {@link AssocArray} values provided by Jawk
+	 */
 	private boolean[] inspectParameters(Method methodParam, Parameter[] parameters) {
 		boolean[] assoc = new boolean[parameters.length];
 		for (int idx = 0; idx < parameters.length; idx++) {

--- a/src/main/java/org/metricshub/jawk/ext/ExtensionFunction.java
+++ b/src/main/java/org/metricshub/jawk/ext/ExtensionFunction.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 
 import org.metricshub.jawk.ext.annotations.JawkAssocArray;
 import org.metricshub.jawk.ext.annotations.JawkFunction;
+import org.metricshub.jawk.jrt.AssocArray;
 import org.metricshub.jawk.jrt.IllegalAwkArgumentException;
 
 /**
@@ -124,11 +125,13 @@ public final class ExtensionFunction implements Serializable {
 				if (parameter.isVarArgs()) {
 					parameterType = parameterType.getComponentType();
 				}
-				if (!Map.class.isAssignableFrom(parameterType)) {
+				if (!Map.class.isAssignableFrom(parameterType)
+						|| !parameterType.isAssignableFrom(AssocArray.class)) {
 					throw new IllegalStateException(
 							"Parameter " + idx + " of " + methodParam
 									+ " annotated with @" + JawkAssocArray.class.getSimpleName()
-									+ " must accept " + Map.class.getName());
+									+ " must accept " + AssocArray.class.getName()
+									+ " instances via " + Map.class.getName());
 				}
 				assoc[idx] = true;
 			}

--- a/src/main/java/org/metricshub/jawk/ext/annotations/JawkAssocArray.java
+++ b/src/main/java/org/metricshub/jawk/ext/annotations/JawkAssocArray.java
@@ -26,9 +26,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Map;
 
 /**
- * Marks an extension function parameter as requiring an associative array.
+ * Marks an extension function parameter as requiring an associative array
+ * backed by a {@link Map}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)

--- a/src/site/markdown/extensions-writing.md
+++ b/src/site/markdown/extensions-writing.md
@@ -39,11 +39,11 @@ The annotation value is the AWK function name seen by the script.
 
 ## Mark Assoc Array Parameters with @JawkAssocArray
 
-Use `@JawkAssocArray` on parameters that must receive an associative array:
+Use `@JawkAssocArray` on parameters that must receive an associative array. Annotated parameters must accept `Map`, which keeps the extension API decoupled from the concrete `AssocArray` implementation Jawk may provide at runtime:
 
 ```java
 @JawkFunction("AssocSize")
-public int assocSize(@JawkAssocArray AssocArray array) {
+public int assocSize(@JawkAssocArray Map<Object, Object> array) {
     return array.keySet().size();
 }
 ```
@@ -81,7 +81,7 @@ public final class SampleExtension extends AbstractExtension {
     }
 
     @JawkFunction("AssocSize")
-    public int assocSize(@JawkAssocArray AssocArray array) {
+    public int assocSize(@JawkAssocArray Map<Object, Object> array) {
         return array.keySet().size();
     }
 }
@@ -111,7 +111,15 @@ Or expose it to the CLI after placing the class on the JVM classpath and registe
 
 ```shell-session
 $ java -cp my-extension.jar -jar jawk-${project.version}-standalone.jar --list-ext
+SampleExtension - com.company.my.SampleExtension
+sample - com.company.my.SampleExtension
+org.metricshub.jawk.ext.StdinExtension - org.metricshub.jawk.ext.StdinExtension
+stdin - org.metricshub.jawk.ext.StdinExtension
+Stdin Support - org.metricshub.jawk.ext.StdinExtension
+StdinExtension - org.metricshub.jawk.ext.StdinExtension
+
 $ java -cp my-extension.jar -jar jawk-${project.version}-standalone.jar -l sample 'BEGIN { print Repeat(3, "ha") }'
+hahaha
 ```
 
 ## See Also

--- a/src/site/markdown/extensions-writing.md
+++ b/src/site/markdown/extensions-writing.md
@@ -39,7 +39,7 @@ The annotation value is the AWK function name seen by the script.
 
 ## Mark Assoc Array Parameters with @JawkAssocArray
 
-Use `@JawkAssocArray` on parameters that must receive an associative array. Annotated parameters must accept `Map`, which keeps the extension API decoupled from the concrete `AssocArray` implementation Jawk may provide at runtime:
+Use `@JawkAssocArray` on parameters that must receive an associative array. Annotated parameters should be declared as `Map`, which keeps the extension API decoupled from the concrete `AssocArray` implementation Jawk provides at runtime. Do not use concrete map classes such as `HashMap` or `TreeMap`, because Jawk passes `AssocArray` instances:
 
 ```java
 @JawkFunction("AssocSize")
@@ -107,12 +107,10 @@ Object value = awk.eval("Repeat(3, \"ha\")");
 // value = "hahaha"
 ```
 
-Or expose it to the CLI after placing the class on the JVM classpath and registering it:
+Or expose it to the CLI after placing the class on the JVM classpath and loading the extension:
 
 ```shell-session
-$ java -cp my-extension.jar -jar jawk-${project.version}-standalone.jar --list-ext
-SampleExtension - com.company.my.SampleExtension
-sample - com.company.my.SampleExtension
+$ java -jar jawk-${project.version}-standalone.jar --list-ext
 org.metricshub.jawk.ext.StdinExtension - org.metricshub.jawk.ext.StdinExtension
 stdin - org.metricshub.jawk.ext.StdinExtension
 Stdin Support - org.metricshub.jawk.ext.StdinExtension

--- a/src/site/markdown/extensions-writing.md
+++ b/src/site/markdown/extensions-writing.md
@@ -107,14 +107,15 @@ Object value = awk.eval("Repeat(3, \"ha\")");
 // value = "hahaha"
 ```
 
-Or expose it to the CLI after placing the class on the JVM classpath and loading the extension:
+Or expose it to the CLI after placing the class on the JVM classpath and registering it:
 
 ```shell-session
-$ java -jar jawk-${project.version}-standalone.jar --list-ext
+$ java -cp my-extension.jar -jar jawk-${project.version}-standalone.jar --list-ext
+SampleExtension - com.company.my.SampleExtension
+sample - com.company.my.SampleExtension
 org.metricshub.jawk.ext.StdinExtension - org.metricshub.jawk.ext.StdinExtension
 stdin - org.metricshub.jawk.ext.StdinExtension
 Stdin Support - org.metricshub.jawk.ext.StdinExtension
-StdinExtension - org.metricshub.jawk.ext.StdinExtension
 
 $ java -cp my-extension.jar -jar jawk-${project.version}-standalone.jar -l sample 'BEGIN { print Repeat(3, "ha") }'
 hahaha

--- a/src/site/markdown/java.md
+++ b/src/site/markdown/java.md
@@ -33,7 +33,7 @@ Construct it with extension instances when you want those functions available to
 Awk awk = new Awk(StdinExtension.INSTANCE, new MyExtension());
 ```
 
-When you write custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values. The dedicated [Writing Extensions](extensions-writing.html) guide covers that contract in more detail.
+When you write custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values rather than concrete map implementations. The dedicated [Writing Extensions](extensions-writing.html) guide covers that contract in more detail.
 
 ## The Shortest Path: run()
 

--- a/src/site/markdown/java.md
+++ b/src/site/markdown/java.md
@@ -33,6 +33,8 @@ Construct it with extension instances when you want those functions available to
 Awk awk = new Awk(StdinExtension.INSTANCE, new MyExtension());
 ```
 
+When you write custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values. The dedicated [Writing Extensions](extensions-writing.html) guide covers that contract in more detail.
+
 ## The Shortest Path: run()
 
 `run()` is the most concise way to execute a full AWK program and collect its printed output as a Java `String`:

--- a/src/test/java/org/metricshub/jawk/ExtensionTest.java
+++ b/src/test/java/org/metricshub/jawk/ExtensionTest.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
+import org.metricshub.jawk.ext.AbstractExtension;
+import org.metricshub.jawk.ext.JawkExtension;
+import org.metricshub.jawk.ext.annotations.JawkAssocArray;
+import org.metricshub.jawk.ext.annotations.JawkFunction;
 import org.metricshub.jawk.AwkTestSupport.TestResult;
 import org.metricshub.jawk.jrt.AwkRuntimeException;
 import org.metricshub.jawk.jrt.IllegalAwkArgumentException;
@@ -78,5 +82,27 @@ public class ExtensionTest {
 			return;
 		}
 		fail("Expected IllegalAwkArgumentException but got " + thrown.getClass().getName());
+	}
+
+	@Test
+	public void testAnnotatedAssocArrayMustAcceptMap() {
+		class InvalidExtension extends AbstractExtension implements JawkExtension {
+
+			@Override
+			public String getExtensionName() {
+				return "invalid";
+			}
+
+			@JawkFunction("invalid")
+			public int invalid(@JawkAssocArray Number value) {
+				return value.intValue();
+			}
+		}
+		try {
+			new InvalidExtension().getExtensionFunctions();
+			fail("Expected IllegalStateException");
+		} catch (IllegalStateException ex) {
+			assertTrue(ex.getMessage().contains("java.util.Map"));
+		}
 	}
 }

--- a/src/test/java/org/metricshub/jawk/ExtensionTest.java
+++ b/src/test/java/org/metricshub/jawk/ExtensionTest.java
@@ -3,12 +3,13 @@ package org.metricshub.jawk;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.HashMap;
 import org.junit.Test;
+import org.metricshub.jawk.AwkTestSupport.TestResult;
 import org.metricshub.jawk.ext.AbstractExtension;
 import org.metricshub.jawk.ext.JawkExtension;
 import org.metricshub.jawk.ext.annotations.JawkAssocArray;
 import org.metricshub.jawk.ext.annotations.JawkFunction;
-import org.metricshub.jawk.AwkTestSupport.TestResult;
 import org.metricshub.jawk.jrt.AwkRuntimeException;
 import org.metricshub.jawk.jrt.IllegalAwkArgumentException;
 
@@ -103,6 +104,28 @@ public class ExtensionTest {
 			fail("Expected IllegalStateException");
 		} catch (IllegalStateException ex) {
 			assertTrue(ex.getMessage().contains("java.util.Map"));
+		}
+	}
+
+	@Test
+	public void testAnnotatedAssocArrayMustNotUseConcreteMapImplementation() {
+		class InvalidExtension extends AbstractExtension implements JawkExtension {
+
+			@Override
+			public String getExtensionName() {
+				return "invalid-map";
+			}
+
+			@JawkFunction("invalid")
+			public int invalid(@JawkAssocArray HashMap<Object, Object> value) {
+				return value.size();
+			}
+		}
+		try {
+			new InvalidExtension().getExtensionFunctions();
+			fail("Expected IllegalStateException");
+		} catch (IllegalStateException ex) {
+			assertTrue(ex.getMessage().contains("AssocArray"));
 		}
 	}
 }

--- a/src/test/java/org/metricshub/jawk/TestExtension.java
+++ b/src/test/java/org/metricshub/jawk/TestExtension.java
@@ -1,5 +1,9 @@
 package org.metricshub.jawk;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import org.metricshub.jawk.ext.AbstractExtension;
 import org.metricshub.jawk.ext.JawkExtension;
@@ -33,8 +37,10 @@ public class TestExtension extends AbstractExtension implements JawkExtension {
 	public String myExtensionFunction(Number count, @JawkAssocArray Map<Object, Object> array) {
 		StringBuilder result = new StringBuilder();
 		int iterations = count.intValue();
+		List<Object> keys = new ArrayList<>(array.keySet());
+		Collections.sort(keys, Comparator.comparing(String::valueOf));
 		for (int i = 0; i < iterations; i++) {
-			for (Object key : array.keySet()) {
+			for (Object key : keys) {
 				result.append(array.get(key));
 			}
 		}

--- a/src/test/java/org/metricshub/jawk/TestExtension.java
+++ b/src/test/java/org/metricshub/jawk/TestExtension.java
@@ -1,10 +1,10 @@
 package org.metricshub.jawk;
 
+import java.util.Map;
 import org.metricshub.jawk.ext.AbstractExtension;
 import org.metricshub.jawk.ext.JawkExtension;
 import org.metricshub.jawk.ext.annotations.JawkAssocArray;
 import org.metricshub.jawk.ext.annotations.JawkFunction;
-import org.metricshub.jawk.jrt.AssocArray;
 
 /**
  * Test extension used by the unit tests to exercise the annotation-based
@@ -30,7 +30,7 @@ public class TestExtension extends AbstractExtension implements JawkExtension {
 	 * @return concatenated string
 	 */
 	@JawkFunction("myExtensionFunction")
-	public String myExtensionFunction(Number count, @JawkAssocArray AssocArray array) {
+	public String myExtensionFunction(Number count, @JawkAssocArray Map<Object, Object> array) {
 		StringBuilder result = new StringBuilder();
 		int iterations = count.intValue();
 		for (int i = 0; i < iterations; i++) {
@@ -47,10 +47,11 @@ public class TestExtension extends AbstractExtension implements JawkExtension {
 	 * @param arrays associative arrays whose key counts should be aggregated
 	 * @return total number of keys across all arrays
 	 */
+	@SafeVarargs
 	@JawkFunction("varArgAssoc")
-	public int varArgAssoc(@JawkAssocArray AssocArray... arrays) {
+	public final int varArgAssoc(@JawkAssocArray Map<?, ?>... arrays) {
 		int total = 0;
-		for (AssocArray array : arrays) {
+		for (Map<?, ?> array : arrays) {
 			total += array.keySet().size();
 		}
 		return total;


### PR DESCRIPTION
## Summary
- change @JawkAssocArray validation to accept Map parameters instead of requiring AssocArray
- update extension tests to exercise Map-typed annotated parameters and reject non-Map annotated parameters
- document the Map contract in the extension authoring docs, Java docs, and README

Closes #429.

## Validation
- mvn formatter:format
- mvn -Dtest=ExtensionTest test
- mvn verify site

Note: the compatibility suite still emits the existing failsafe noise on this repo's Windows setup, but the build remains green because those tests are configured with testFailureIgnore=true.