### PR TITLE
Add optional gawk-style arrays of arrays (`a[i][j]`)

### DIFF
--- a/src/main/java/io/jawk/Awk.java
+++ b/src/main/java/io/jawk/Awk.java
@@ -472,7 +472,7 @@ public class Awk {
 		lastAst = null;
 		if (!scripts.isEmpty()) {
 			// Parse all script sources into a single AST
-			AwkParser parser = new AwkParser(this.extensionFunctions);
+			AwkParser parser = new AwkParser(this.extensionFunctions, settings.isAllowArraysOfArrays());
 			AstNode ast = parser.parse(scripts);
 			lastAst = ast;
 			if (ast != null) {
@@ -539,7 +539,7 @@ public class Awk {
 				new StringReader(expression));
 
 		// Parse the expression
-		AwkParser parser = new AwkParser(this.extensionFunctions);
+		AwkParser parser = new AwkParser(this.extensionFunctions, settings.isAllowArraysOfArrays());
 		AstNode ast = parser.parseExpression(expressionSource);
 
 		// Attempt to traverse the syntax tree and build

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -709,6 +709,16 @@ public class AVM implements VariableManager, Closeable {
 					position.next();
 					break;
 				}
+				case BLANK_TO_ZERO: {
+					Object value = pop();
+					if (value == null || value instanceof UninitializedObject) {
+						push(ZERO);
+					} else {
+						push(value);
+					}
+					position.next();
+					break;
+				}
 				case IFTRUE: {
 					// arg[0] = address to jump to if top of stack is true
 					// stack[0] = item to check

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -649,7 +649,12 @@ public class AVM implements VariableManager, Closeable {
 						// display $0
 						push(jrt.jrtGetInputField(0).toString().length());
 					} else {
-						push(pop().toString().length());
+						Object value = pop();
+						if (value instanceof Map) {
+							push((long) ((Map<?, ?>) value).size());
+						} else {
+							push(jrt.toAwkString(value).length());
+						}
 					}
 					position.next();
 					break;
@@ -804,6 +809,20 @@ public class AVM implements VariableManager, Closeable {
 					position.next();
 					break;
 				}
+				case ASSIGN_MAP_ELEMENT: {
+					// stack[0] = array index
+					// stack[1] = associative array
+					// stack[2] = value
+					Object arrIdx = pop();
+					Map<Object, Object> array = toMap(pop());
+					Object rhs = pop();
+					if (rhs == null) {
+						rhs = BLANK;
+					}
+					assignMapElement(array, arrIdx, rhs);
+					position.next();
+					break;
+				}
 				case PLUS_EQ_ARRAY:
 				case MINUS_EQ_ARRAY:
 				case MULT_EQ_ARRAY:
@@ -825,6 +844,7 @@ public class AVM implements VariableManager, Closeable {
 					double val = JRT.toDouble(rhs);
 
 					Map<Object, Object> array = ensureMapVariable(offset, isGlobal);
+					checkScalar(arrIdx);
 					Object o = array.get(arrIdx);
 					double origVal = JRT.toDouble(o);
 
@@ -857,6 +877,59 @@ public class AVM implements VariableManager, Closeable {
 						assignArray(offset, arrIdx, (long) Math.rint(newVal), isGlobal);
 					} else {
 						assignArray(offset, arrIdx, newVal, isGlobal);
+					}
+					position.next();
+					break;
+				}
+				case PLUS_EQ_MAP_ELEMENT:
+				case MINUS_EQ_MAP_ELEMENT:
+				case MULT_EQ_MAP_ELEMENT:
+				case DIV_EQ_MAP_ELEMENT:
+				case MOD_EQ_MAP_ELEMENT:
+				case POW_EQ_MAP_ELEMENT: {
+					// stack[0] = array index
+					// stack[1] = associative array
+					// stack[2] = value
+					Object arrIdx = pop();
+					Map<Object, Object> array = toMap(pop());
+					Object rhs = pop();
+					if (rhs == null) {
+						rhs = BLANK;
+					}
+
+					double val = JRT.toDouble(rhs);
+					checkScalar(arrIdx);
+					Object o = array.get(arrIdx);
+					double origVal = JRT.toDouble(o);
+					double newVal;
+
+					switch (opcode) {
+					case PLUS_EQ_MAP_ELEMENT:
+						newVal = origVal + val;
+						break;
+					case MINUS_EQ_MAP_ELEMENT:
+						newVal = origVal - val;
+						break;
+					case MULT_EQ_MAP_ELEMENT:
+						newVal = origVal * val;
+						break;
+					case DIV_EQ_MAP_ELEMENT:
+						newVal = origVal / val;
+						break;
+					case MOD_EQ_MAP_ELEMENT:
+						newVal = origVal % val;
+						break;
+					case POW_EQ_MAP_ELEMENT:
+						newVal = Math.pow(origVal, val);
+						break;
+					default:
+						throw new Error("Invalid op code here: " + opcode);
+					}
+
+					if (JRT.isActuallyLong(newVal)) {
+						assignMapElement(array, arrIdx, (long) Math.rint(newVal));
+					} else {
+						assignMapElement(array, arrIdx, newVal);
 					}
 					position.next();
 					break;
@@ -1020,6 +1093,7 @@ public class AVM implements VariableManager, Closeable {
 					boolean isGlobal = position.boolArg(1);
 					Map<Object, Object> aa = ensureMapVariable(position.intArg(0), isGlobal);
 					Object key = pop();
+					checkScalar(key);
 					Object o = aa.get(key);
 					double ans = JRT.toDouble(o) + 1;
 					if (JRT.isActuallyLong(ans)) {
@@ -1037,6 +1111,39 @@ public class AVM implements VariableManager, Closeable {
 					boolean isGlobal = position.boolArg(1);
 					Map<Object, Object> aa = ensureMapVariable(position.intArg(0), isGlobal);
 					Object key = pop();
+					checkScalar(key);
+					Object o = aa.get(key);
+					double ans = JRT.toDouble(o) - 1;
+					if (JRT.isActuallyLong(ans)) {
+						aa.put(key, (long) Math.rint(ans));
+					} else {
+						aa.put(key, ans);
+					}
+					position.next();
+					break;
+				}
+				case INC_MAP_REF: {
+					// stack[0] = array index
+					// stack[1] = associative array
+					Object key = pop();
+					checkScalar(key);
+					Map<Object, Object> aa = toMap(pop());
+					Object o = aa.get(key);
+					double ans = JRT.toDouble(o) + 1;
+					if (JRT.isActuallyLong(ans)) {
+						aa.put(key, (long) Math.rint(ans));
+					} else {
+						aa.put(key, ans);
+					}
+					position.next();
+					break;
+				}
+				case DEC_MAP_REF: {
+					// stack[0] = array index
+					// stack[1] = associative array
+					Object key = pop();
+					checkScalar(key);
+					Map<Object, Object> aa = toMap(pop());
 					Object o = aa.get(key);
 					double ans = JRT.toDouble(o) - 1;
 					if (JRT.isActuallyLong(ans)) {
@@ -1105,14 +1212,19 @@ public class AVM implements VariableManager, Closeable {
 				case DEREF_ARRAY: {
 					// stack[0] = array index
 					Object idx = pop(); // idx
-					Object array = pop(); // map
-					if (!(array instanceof Map)) {
-						throw new AwkRuntimeException("Attempting to index a non-associative-array.");
-					}
-					@SuppressWarnings("unchecked")
-					Map<Object, Object> map = (Map<Object, Object>) array;
+					checkScalar(idx);
+					Map<Object, Object> map = toMap(pop());
 					Object o = JRT.getAwkValue(map, idx);
 					push(o);
+					position.next();
+					break;
+				}
+				case ENSURE_ARRAY_ELEMENT: {
+					// stack[0] = array index
+					// stack[1] = associative array
+					Object idx = pop();
+					Map<Object, Object> map = toMap(pop());
+					push(ensureArrayInArray(map, idx));
 					position.next();
 					break;
 				}
@@ -1318,6 +1430,21 @@ public class AVM implements VariableManager, Closeable {
 					String newString = execSubOrGSub(position, 2);
 					// assign it to "offset/arrIdx/global"
 					assignArray(offset, arrIdx, newString, isGlobal);
+					pop();
+					position.next();
+					break;
+				}
+				case SUB_FOR_MAP_REFERENCE: {
+					// arg[0] = isGsub
+					// stack[0] = array index
+					// stack[1] = associative array
+					// stack[2] = original variable value
+					// stack[3] = replacement string
+					// stack[4] = ere
+					Object arrIdx = pop();
+					Map<Object, Object> array = toMap(pop());
+					String newString = execSubOrGSub(position, 0);
+					assignMapElement(array, arrIdx, newString);
 					pop();
 					position.next();
 					break;
@@ -1849,14 +1976,20 @@ public class AVM implements VariableManager, Closeable {
 					long count = position.intArg(0);
 					// String s;
 					if (count == 1) {
-						push(jrt.toAwkString(pop()));
+						Object value = pop();
+						checkScalar(value);
+						push(jrt.toAwkString(value));
 					} else {
 						StringBuilder sb = new StringBuilder();
-						sb.append(jrt.toAwkString(pop()));
+						Object value = pop();
+						checkScalar(value);
+						sb.append(jrt.toAwkString(value));
 						String subsep = jrt.toAwkString(jrt.getSUBSEPVar());
 						for (int i = 1; i < count; i++) {
 							sb.insert(0, subsep);
-							sb.insert(0, jrt.toAwkString(pop()));
+							value = pop();
+							checkScalar(value);
+							sb.insert(0, jrt.toAwkString(value));
 						}
 						push(sb.toString());
 					}
@@ -1871,9 +2004,20 @@ public class AVM implements VariableManager, Closeable {
 					boolean isGlobal = position.boolArg(1);
 					Map<Object, Object> aa = getMapVariable(offset, isGlobal);
 					Object key = pop();
+					checkScalar(key);
 					if (aa != null) {
 						aa.remove(key);
 					}
+					position.next();
+					break;
+				}
+				case DELETE_MAP_ELEMENT: {
+					// stack[0] = array index
+					// stack[1] = associative array
+					Object key = pop();
+					checkScalar(key);
+					Map<Object, Object> aa = toMap(pop());
+					aa.remove(key);
 					position.next();
 					break;
 				}
@@ -1954,6 +2098,7 @@ public class AVM implements VariableManager, Closeable {
 					// stack[1] = key to check
 					Object arr = pop();
 					Object arg = pop();
+					checkScalar(arg);
 					if (!(arr instanceof Map)) {
 						throw new AwkRuntimeException("Attempting to test membership on a non-associative-array.");
 					}
@@ -2378,7 +2523,11 @@ public class AVM implements VariableManager, Closeable {
 	 * Awk array element assignment functionality.
 	 */
 	private void assignArray(long offset, Object arrIdx, Object rhs, boolean isGlobal) {
-		Map<Object, Object> array = ensureMapVariable(offset, isGlobal);
+		assignMapElement(ensureMapVariable(offset, isGlobal), arrIdx, rhs);
+	}
+
+	private void assignMapElement(Map<Object, Object> array, Object arrIdx, Object rhs) {
+		checkScalar(arrIdx);
 		array.put(arrIdx, rhs);
 		push(rhs);
 	}
@@ -2616,6 +2765,13 @@ public class AVM implements VariableManager, Closeable {
 		return toMap(value);
 	}
 
+	/**
+	 * Casts an AWK value to an associative array.
+	 *
+	 * @param value value to validate
+	 * @return the associative array value
+	 * @throws AwkRuntimeException when {@code value} is scalar
+	 */
 	private Map<Object, Object> toMap(Object value) {
 		if (!(value instanceof Map)) {
 			throw new AwkRuntimeException("Attempting to treat a scalar as an array.");
@@ -2623,6 +2779,45 @@ public class AVM implements VariableManager, Closeable {
 		@SuppressWarnings("unchecked")
 		Map<Object, Object> map = (Map<Object, Object>) value;
 		return map;
+	}
+
+	/**
+	 * Ensures a value is scalar before using it in a scalar-only context such as
+	 * a subscript component.
+	 *
+	 * @param value value to validate
+	 * @throws AwkRuntimeException when {@code value} is an array
+	 */
+	private void checkScalar(Object value) {
+		if (value instanceof Map) {
+			throw new AwkRuntimeException("Attempting to use an array in a scalar context.");
+		}
+	}
+
+	/**
+	 * Returns the nested associative array stored in {@code map[key]}, creating it
+	 * when the key is undefined.
+	 *
+	 * @param map containing array
+	 * @param key nested-array key
+	 * @return the nested associative array stored at {@code key}
+	 * @throws AwkRuntimeException when {@code key} is scalar-incompatible or when
+	 *         the existing slot contains a scalar
+	 */
+	private Map<Object, Object> ensureArrayInArray(Map<Object, Object> map, Object key) {
+		checkScalar(key);
+		Object value = JRT.getAwkValue(map, key);
+		if (value == null || value.equals(BLANK) || value instanceof UninitializedObject) {
+			Map<Object, Object> nested = newAwkArray();
+			map.put(key, nested);
+			return nested;
+		}
+		if (!(value instanceof Map)) {
+			throw new AwkRuntimeException("Attempting to use a scalar as an array.");
+		}
+		@SuppressWarnings("unchecked")
+		Map<Object, Object> nested = (Map<Object, Object>) value;
+		return nested;
 	}
 
 	private static final UninitializedObject BLANK = new UninitializedObject();

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -52,6 +52,7 @@ import io.jawk.intermediate.Address;
 import io.jawk.intermediate.Opcode;
 import io.jawk.intermediate.PositionTracker;
 import io.jawk.intermediate.UninitializedObject;
+import io.jawk.jrt.AssocArray;
 import io.jawk.jrt.AwkRuntimeException;
 import io.jawk.jrt.AwkSink;
 import io.jawk.jrt.BlockManager;
@@ -709,16 +710,6 @@ public class AVM implements VariableManager, Closeable {
 					position.next();
 					break;
 				}
-				case BLANK_TO_ZERO: {
-					Object value = pop();
-					if (value == null || value instanceof UninitializedObject) {
-						push(ZERO);
-					} else {
-						push(value);
-					}
-					position.next();
-					break;
-				}
 				case IFTRUE: {
 					// arg[0] = address to jump to if top of stack is true
 					// stack[0] = item to check
@@ -1238,6 +1229,20 @@ public class AVM implements VariableManager, Closeable {
 					position.next();
 					break;
 				}
+				case PEEK_ARRAY_ELEMENT: {
+					// stack[0] = array index
+					Object idx = pop();
+					checkScalar(idx);
+					Map<Object, Object> map = toMap(pop());
+					if (map instanceof AssocArray && !JRT.containsAwkKey(map, idx)) {
+						push(BLANK);
+					} else {
+						Object value = map.get(idx);
+						push(value != null ? value : BLANK);
+					}
+					position.next();
+					break;
+				}
 				case SRAND: {
 					// arg[0] = numArgs (where 0 = no args, anything else = one argument)
 					// stack[0] = seed (only if numArgs != 0)
@@ -1719,6 +1724,11 @@ public class AVM implements VariableManager, Closeable {
 				}
 				case KEYLIST: {
 					Object o = pop();
+					if (o == null || o instanceof UninitializedObject) {
+						push(new ArrayDeque<>());
+						position.next();
+						break;
+					}
 					if (!(o instanceof Map)) {
 						throw new AwkRuntimeException(
 								position.lineNumber(),
@@ -2109,6 +2119,11 @@ public class AVM implements VariableManager, Closeable {
 					Object arr = pop();
 					Object arg = pop();
 					checkScalar(arg);
+					if (arr == null || arr instanceof UninitializedObject) {
+						push(ZERO);
+						position.next();
+						break;
+					}
 					if (!(arr instanceof Map)) {
 						throw new AwkRuntimeException("Attempting to test membership on a non-associative-array.");
 					}

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -3123,7 +3123,7 @@ public class AwkParser {
 
 			breakAddress = tuples.createAddress("breakAddress");
 
-			populateArrayOperandTuples(getAst2(), tuples, true, getAst2() + " is not an array");
+			populateArrayOperandTuples(getAst2(), tuples, false, getAst2() + " is not an array");
 			// pops the array and pushes the keyset
 			tuples.keylist();
 
@@ -3468,7 +3468,7 @@ public class AwkParser {
 			}
 
 			getAst1().populateTuples(tuples);
-			populateArrayOperandTuples(getAst2(), tuples, true, "Expecting an array for rhs of IN. Got a scalar.");
+			populateArrayOperandTuples(getAst2(), tuples, false, "Expecting an array for rhs of IN. Got a scalar.");
 			tuples.isIn();
 
 			popSourceLineNumber(tuples);
@@ -4479,7 +4479,7 @@ public class AwkParser {
 			if (createIfMissing) {
 				tuples.ensureArrayElement();
 			} else {
-				tuples.dereferenceArray();
+				tuples.peekArrayElement();
 			}
 			popSourceLineNumber(tuples);
 		}
@@ -4764,7 +4764,7 @@ public class AwkParser {
 			} else {
 				if (getAst1() instanceof ArrayReferenceAst) {
 					((ArrayReferenceAst) getAst1()).populateTargetValueTuples(tuples);
-					tuples.blankToZero();
+					tuples.unaryPlus();
 				} else {
 					getAst1().populateTuples(tuples);
 				}
@@ -4802,7 +4802,7 @@ public class AwkParser {
 			pushSourceLineNumber(tuples);
 			if (getAst1() instanceof ArrayReferenceAst) {
 				((ArrayReferenceAst) getAst1()).populateTargetValueTuples(tuples);
-				tuples.blankToZero();
+				tuples.unaryPlus();
 			} else {
 				getAst1().populateTuples(tuples);
 			}

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -376,6 +376,16 @@ public class AwkParser {
 	}
 
 	/**
+	 * Returns the current 1-based source line number to stamp onto AST nodes that
+	 * will later emit tuple line markers for runtime error reporting.
+	 *
+	 * @return current source line number using 1-based counting
+	 */
+	private int currentSourceLineNumber() {
+		return reader.getLineNumber() + 1;
+	}
+
+	/**
 	 * Reads the string and handle all escape codes.
 	 *
 	 * @throws IOException
@@ -1553,7 +1563,7 @@ public class AwkParser {
 			}
 		}
 		if (token == Token.OPEN_BRACKET) {
-			int arrayReferenceLineNo = reader.getLineNumber() + 1;
+			int arrayReferenceLineNo = currentSourceLineNumber();
 			lexer();
 			AST idxAst = ARRAY_INDEX(true, allowInKeyword);
 			lexer(Token.CLOSE_BRACKET);
@@ -1562,7 +1572,7 @@ public class AwkParser {
 				throw parserException("Use [a,b,c,...] instead of [a][b][c]... for multi-dimensional arrays.");
 			}
 			while (allowArraysOfArrays && token == Token.OPEN_BRACKET) {
-				int nestedArrayReferenceLineNo = reader.getLineNumber() + 1;
+				int nestedArrayReferenceLineNo = currentSourceLineNumber();
 				lexer();
 				idxAst = ARRAY_INDEX(true, allowInKeyword);
 				lexer(Token.CLOSE_BRACKET);
@@ -2128,6 +2138,8 @@ public class AwkParser {
 	private abstract class AST extends AstNode {
 
 		private final String sourceDescription = scriptSources.get(scriptSourcesCurrentIndex).getDescription();
+		// PositionTracker consumes these tuple-emitted source lines at runtime, but
+		// AST nodes have to capture them here during parsing before tuples exist.
 		private final int lineNo;
 		private AST parent;
 		private AST ast1, ast2, ast3, ast4;
@@ -2214,7 +2226,7 @@ public class AwkParser {
 		}
 
 		protected AST() {
-			this(reader.getLineNumber() + 1);
+			this(currentSourceLineNumber());
 		}
 
 		protected AST(int lineNo) {
@@ -2222,7 +2234,7 @@ public class AwkParser {
 		}
 
 		protected AST(AST ast1) {
-			this(reader.getLineNumber() + 1, ast1);
+			this(currentSourceLineNumber(), ast1);
 		}
 
 		protected AST(int lineNo, AST ast1) {
@@ -2235,7 +2247,7 @@ public class AwkParser {
 		}
 
 		protected AST(AST ast1, AST ast2) {
-			this(reader.getLineNumber() + 1, ast1, ast2);
+			this(currentSourceLineNumber(), ast1, ast2);
 		}
 
 		protected AST(int lineNo, AST ast1, AST ast2) {
@@ -2252,7 +2264,7 @@ public class AwkParser {
 		}
 
 		protected AST(AST ast1, AST ast2, AST ast3) {
-			this(reader.getLineNumber() + 1, ast1, ast2, ast3);
+			this(currentSourceLineNumber(), ast1, ast2, ast3);
 		}
 
 		protected AST(int lineNo, AST ast1, AST ast2, AST ast3) {
@@ -2273,7 +2285,7 @@ public class AwkParser {
 		}
 
 		protected AST(AST ast1, AST ast2, AST ast3, AST ast4) {
-			this(reader.getLineNumber() + 1, ast1, ast2, ast3, ast4);
+			this(currentSourceLineNumber(), ast1, ast2, ast3, ast4);
 		}
 
 		protected AST(int lineNo, AST ast1, AST ast2, AST ast3, AST ast4) {

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -1553,18 +1553,20 @@ public class AwkParser {
 			}
 		}
 		if (token == Token.OPEN_BRACKET) {
+			int arrayReferenceLineNo = reader.getLineNumber() + 1;
 			lexer();
 			AST idxAst = ARRAY_INDEX(true, allowInKeyword);
 			lexer(Token.CLOSE_BRACKET);
-			AST arrayReference = symbolTable.addArrayReference(id, idxAst);
+			AST arrayReference = symbolTable.addArrayReference(id, idxAst, arrayReferenceLineNo);
 			if (!allowArraysOfArrays && token == Token.OPEN_BRACKET) {
 				throw parserException("Use [a,b,c,...] instead of [a][b][c]... for multi-dimensional arrays.");
 			}
 			while (allowArraysOfArrays && token == Token.OPEN_BRACKET) {
+				int nestedArrayReferenceLineNo = reader.getLineNumber() + 1;
 				lexer();
 				idxAst = ARRAY_INDEX(true, allowInKeyword);
 				lexer(Token.CLOSE_BRACKET);
-				arrayReference = new ArrayReferenceAst(arrayReference, idxAst);
+				arrayReference = new ArrayReferenceAst(nestedArrayReferenceLineNo, arrayReference, idxAst);
 			}
 			return arrayReference;
 		}
@@ -2126,7 +2128,7 @@ public class AwkParser {
 	private abstract class AST extends AstNode {
 
 		private final String sourceDescription = scriptSources.get(scriptSourcesCurrentIndex).getDescription();
-		private final int lineNo = reader.getLineNumber() + 1;
+		private final int lineNo;
 		private AST parent;
 		private AST ast1, ast2, ast3, ast4;
 		private final EnumSet<AstFlag> flags = EnumSet.noneOf(AstFlag.class);
@@ -2211,9 +2213,20 @@ public class AwkParser {
 			return null;
 		}
 
-		protected AST() {}
+		protected AST() {
+			this(reader.getLineNumber() + 1);
+		}
+
+		protected AST(int lineNo) {
+			this.lineNo = lineNo;
+		}
 
 		protected AST(AST ast1) {
+			this(reader.getLineNumber() + 1, ast1);
+		}
+
+		protected AST(int lineNo, AST ast1) {
+			this(lineNo);
 			this.ast1 = ast1;
 
 			if (ast1 != null) {
@@ -2222,6 +2235,11 @@ public class AwkParser {
 		}
 
 		protected AST(AST ast1, AST ast2) {
+			this(reader.getLineNumber() + 1, ast1, ast2);
+		}
+
+		protected AST(int lineNo, AST ast1, AST ast2) {
+			this(lineNo);
 			this.ast1 = ast1;
 			this.ast2 = ast2;
 
@@ -2234,6 +2252,11 @@ public class AwkParser {
 		}
 
 		protected AST(AST ast1, AST ast2, AST ast3) {
+			this(reader.getLineNumber() + 1, ast1, ast2, ast3);
+		}
+
+		protected AST(int lineNo, AST ast1, AST ast2, AST ast3) {
+			this(lineNo);
 			this.ast1 = ast1;
 			this.ast2 = ast2;
 			this.ast3 = ast3;
@@ -2250,6 +2273,11 @@ public class AwkParser {
 		}
 
 		protected AST(AST ast1, AST ast2, AST ast3, AST ast4) {
+			this(reader.getLineNumber() + 1, ast1, ast2, ast3, ast4);
+		}
+
+		protected AST(int lineNo, AST ast1, AST ast2, AST ast3, AST ast4) {
+			this(lineNo);
 			this.ast1 = ast1;
 			this.ast2 = ast2;
 			this.ast3 = ast3;
@@ -2475,16 +2503,32 @@ public class AwkParser {
 			super();
 		}
 
+		protected ScalarExpressionAst(int lineNo) {
+			super(lineNo);
+		}
+
 		protected ScalarExpressionAst(AST a1) {
 			super(a1);
+		}
+
+		protected ScalarExpressionAst(int lineNo, AST a1) {
+			super(lineNo, a1);
 		}
 
 		protected ScalarExpressionAst(AST a1, AST a2) {
 			super(a1, a2);
 		}
 
+		protected ScalarExpressionAst(int lineNo, AST a1, AST a2) {
+			super(lineNo, a1, a2);
+		}
+
 		protected ScalarExpressionAst(AST a1, AST a2, AST a3) {
 			super(a1, a2, a3);
+		}
+
+		protected ScalarExpressionAst(int lineNo, AST a1, AST a2, AST a3) {
+			super(lineNo, a1, a2, a3);
 		}
 
 		@Override
@@ -4388,6 +4432,10 @@ public class AwkParser {
 			super(idAst, idxAst);
 		}
 
+		private ArrayReferenceAst(int lineNo, AST idAst, AST idxAst) {
+			super(lineNo, idAst, idxAst);
+		}
+
 		@Override
 		public String toString() {
 			return super.toString() + " (" + getAst1() + " [...])";
@@ -5376,8 +5424,8 @@ public class AwkParser {
 			return new FunctionCallAst(functionProxy, paramList);
 		}
 
-		AST addArrayReference(String id, AST idxAst) throws ParserException {
-			return new ArrayReferenceAst(addArrayID(id), idxAst);
+		AST addArrayReference(String id, AST idxAst, int lineNo) throws ParserException {
+			return new ArrayReferenceAst(lineNo, addArrayID(id), idxAst);
 		}
 
 		// constants are no longer cached/hashed so that individual ASTs

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -4704,6 +4704,7 @@ public class AwkParser {
 			} else {
 				if (getAst1() instanceof ArrayReferenceAst) {
 					((ArrayReferenceAst) getAst1()).populateTargetValueTuples(tuples);
+					tuples.blankToZero();
 				} else {
 					getAst1().populateTuples(tuples);
 				}
@@ -4741,6 +4742,7 @@ public class AwkParser {
 			pushSourceLineNumber(tuples);
 			if (getAst1() instanceof ArrayReferenceAst) {
 				((ArrayReferenceAst) getAst1()).populateTargetValueTuples(tuples);
+				tuples.blankToZero();
 			} else {
 				getAst1().populateTuples(tuples);
 			}

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -2069,6 +2069,9 @@ public class AwkParser {
 			return;
 		}
 		if (arrayAst instanceof ArrayReferenceAst) {
+			if (!allowArraysOfArrays) {
+				arrayAst.throwSemanticException(errorMessage);
+			}
 			((ArrayReferenceAst) arrayAst).populateArrayValueTuples(tuples, createIfMissing);
 			return;
 		}
@@ -2088,7 +2091,7 @@ public class AwkParser {
 					params.getAst1(),
 					tuples,
 					true,
-					"Parameter position " + parameterIndex + " must be an array or subarray.");
+					"Parameter position " + (parameterIndex + 1) + " must be an array or subarray.");
 		} else {
 			params.getAst1().populateTuples(tuples);
 		}
@@ -4393,8 +4396,8 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			// get the array var
-			getAst1().populateTuples(tuples);
+			// get the containing array, autovivifying missing parent subarrays
+			populateContainerTuples(tuples);
 			// get the index
 			getAst2().populateTuples(tuples);
 			tuples.dereferenceArray();

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -267,6 +267,7 @@ public class AwkParser {
 	private final AwkSymbolTableImpl symbolTable = new AwkSymbolTableImpl();
 
 	private final Map<String, ExtensionFunction> extensions;
+	private final boolean allowArraysOfArrays;
 
 	/**
 	 * <p>
@@ -275,8 +276,9 @@ public class AwkParser {
 	 *
 	 * @param extensions a {@link java.util.Map} object
 	 */
-	public AwkParser(Map<String, ExtensionFunction> extensions) {
+	public AwkParser(Map<String, ExtensionFunction> extensions, boolean allowArraysOfArrays) {
 		this.extensions = extensions == null ? Collections.emptyMap() : new HashMap<>(extensions);
+		this.allowArraysOfArrays = allowArraysOfArrays;
 	}
 
 	private List<ScriptSource> scriptSources;
@@ -1554,10 +1556,17 @@ public class AwkParser {
 			lexer();
 			AST idxAst = ARRAY_INDEX(true, allowInKeyword);
 			lexer(Token.CLOSE_BRACKET);
-			if (token == Token.OPEN_BRACKET) {
+			AST arrayReference = symbolTable.addArrayReference(id, idxAst);
+			if (!allowArraysOfArrays && token == Token.OPEN_BRACKET) {
 				throw parserException("Use [a,b,c,...] instead of [a][b][c]... for multi-dimensional arrays.");
 			}
-			return symbolTable.addArrayReference(id, idxAst);
+			while (allowArraysOfArrays && token == Token.OPEN_BRACKET) {
+				lexer();
+				idxAst = ARRAY_INDEX(true, allowInKeyword);
+				lexer(Token.CLOSE_BRACKET);
+				arrayReference = new ArrayReferenceAst(arrayReference, idxAst);
+			}
+			return arrayReference;
 		}
 		return symbolTable.addID(id);
 	}
@@ -1747,21 +1756,15 @@ public class AwkParser {
 			}
 			// in
 			lexer();
-			// id
 			if (token != Token.ID) {
 				throw parserException(
-						"Expecting an ARRAY Token.ID for 'in' statement. Got " + token.name() + ": " + text);
+						"Expecting an array or subarray for 'in' statement. Got " + token.name() + ": " + text);
 			}
-			String arrId = text.toString();
-
-			// not an indexed array reference!
-			AST arrayIdAst = symbolTable.addArrayID(arrId);
-
-			lexer();
+			AST arrayAst = SYMBOL(true, true);
 			// close paren ...
 			lexer(Token.CLOSE_PAREN);
 			AST block = BLOCK_OR_STMT();
-			return new ForInStatementAst(expr1, arrayIdAst, block);
+			return new ForInStatementAst(expr1, arrayAst, block);
 		}
 
 		if (token == Token.SEMICOLON) {
@@ -2049,6 +2052,69 @@ public class AwkParser {
 		} else {
 			throw parserException("Expecting " + keyword + ". Got " + token.name() + ": " + text);
 		}
+	}
+
+	private void populateArrayOperandTuples(
+			AST arrayAst,
+			AwkTuples tuples,
+			boolean createIfMissing,
+			String errorMessage) {
+		if (arrayAst instanceof IDAst) {
+			IDAst idAst = (IDAst) arrayAst;
+			if (idAst.isScalar()) {
+				arrayAst.throwSemanticException(errorMessage);
+			}
+			idAst.setArray(true);
+			idAst.populateTuples(tuples);
+			return;
+		}
+		if (arrayAst instanceof ArrayReferenceAst) {
+			((ArrayReferenceAst) arrayAst).populateArrayValueTuples(tuples, createIfMissing);
+			return;
+		}
+		arrayAst.throwSemanticException(errorMessage);
+	}
+
+	private int populateActualParameters(
+			AwkTuples tuples,
+			FunctionCallParamListAst params,
+			Set<Integer> arrayParameterIndexes,
+			int parameterIndex) {
+		if (params == null) {
+			return 0;
+		}
+		if (arrayParameterIndexes.contains(Integer.valueOf(parameterIndex))) {
+			populateArrayOperandTuples(
+					params.getAst1(),
+					tuples,
+					true,
+					"Parameter position " + parameterIndex + " must be an array or subarray.");
+		} else {
+			params.getAst1().populateTuples(tuples);
+		}
+		if (params.getAst2() == null) {
+			return 1;
+		}
+		return 1 + populateActualParameters(
+				tuples,
+				(FunctionCallParamListAst) params.getAst2(),
+				arrayParameterIndexes,
+				parameterIndex + 1);
+	}
+
+	private Set<Integer> collectArrayParameterIndexes(FunctionDefAst functionDefAst) {
+		Set<Integer> arrayIndexes = new HashSet<Integer>();
+		FunctionDefParamListAst fPtr = (FunctionDefParamListAst) functionDefAst.getAst1();
+		int index = 0;
+		while (fPtr != null) {
+			IDAst fparam = symbolTable.getFunctionParameterIDAST(functionDefAst.id, fPtr.id);
+			if (fparam.isArray()) {
+				arrayIndexes.add(Integer.valueOf(index));
+			}
+			fPtr = (FunctionDefParamListAst) fPtr.getAst1();
+			index++;
+		}
+		return arrayIndexes;
 	}
 
 	// parser
@@ -2996,15 +3062,9 @@ public class AwkParser {
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
 
-			IDAst arrayIdAst = (IDAst) getAst2();
-			if (arrayIdAst.isScalar()) {
-				throw new SemanticException(arrayIdAst + " is not an array");
-			}
-			arrayIdAst.setArray(true);
-
 			breakAddress = tuples.createAddress("breakAddress");
 
-			getAst2().populateTuples(tuples);
+			populateArrayOperandTuples(getAst2(), tuples, true, getAst2() + " is not an array");
 			// pops the array and pushes the keyset
 			tuples.keylist();
 
@@ -3182,27 +3242,28 @@ public class AwkParser {
 				}
 			} else if (getAst1() instanceof ArrayReferenceAst) {
 				ArrayReferenceAst arr = (ArrayReferenceAst) getAst1();
-				// push the index
-				arr.getAst2().populateTuples(tuples); // push the array ref itself
-				IDAst idAst = (IDAst) arr.getAst1();
-				if (idAst.isScalar()) {
-					throw new SemanticException("Cannot use " + idAst + " as an array. It is a scalar.");
+				if (arr.getAst1() instanceof IDAst) {
+					IDAst idAst = (IDAst) arr.getAst1();
+					if (idAst.isScalar()) {
+						throw new SemanticException("Cannot use " + idAst + " as an array. It is a scalar.");
+					}
+					idAst.setArray(true);
 				}
-				idAst.setArray(true);
+				arr.populateTargetReferenceTuples(tuples);
 				if (op == Token.EQUALS) {
-					tuples.assignArray(idAst.offset, idAst.isGlobal);
+					tuples.assignMapElement();
 				} else if (op == Token.PLUS_EQ) {
-					tuples.plusEqArray(idAst.offset, idAst.isGlobal);
+					tuples.plusEqMapElement();
 				} else if (op == Token.MINUS_EQ) {
-					tuples.minusEqArray(idAst.offset, idAst.isGlobal);
+					tuples.minusEqMapElement();
 				} else if (op == Token.MULT_EQ) {
-					tuples.multEqArray(idAst.offset, idAst.isGlobal);
+					tuples.multEqMapElement();
 				} else if (op == Token.DIV_EQ) {
-					tuples.divEqArray(idAst.offset, idAst.isGlobal);
+					tuples.divEqMapElement();
 				} else if (op == Token.MOD_EQ) {
-					tuples.modEqArray(idAst.offset, idAst.isGlobal);
+					tuples.modEqMapElement();
 				} else if (op == Token.POW_EQ) {
-					tuples.powEqArray(idAst.offset, idAst.isGlobal);
+					tuples.powEqMapElement();
 				} else {
 					throw new NotImplementedError("Unhandled op: " + op + " / " + text + " for arrays.");
 				}
@@ -3343,17 +3404,12 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			if (!(getAst2() instanceof IDAst)) {
+			if (!(getAst2() instanceof IDAst) && !(getAst2() instanceof ArrayReferenceAst)) {
 				throw new SemanticException("Expecting an array for rhs of IN. Got an expression.");
 			}
-			IDAst arrAst = (IDAst) getAst2();
-			if (arrAst.isScalar()) {
-				throw new SemanticException("Expecting an array for rhs of IN. Got a scalar.");
-			}
-			arrAst.setArray(true);
 
 			getAst1().populateTuples(tuples);
-			arrAst.populateTuples(tuples);
+			populateArrayOperandTuples(getAst2(), tuples, true, "Expecting an array for rhs of IN. Got a scalar.");
 			tuples.isIn();
 
 			popSourceLineNumber(tuples);
@@ -3722,26 +3778,30 @@ public class AwkParser {
 				// formal function parameter
 				AST fparam = symbolTable.getFunctionParameterIDAST(id, fPtr.id);
 
-				if (aparam.isArray() && fparam.isScalar()) {
-					aparam
-							.throwSemanticException(
-									id + ": Actual parameter (" + aparam + ") is an array, but formal parameter is used like a scalar.");
-				}
-				if (aparam.isScalar() && fparam.isArray()) {
-					aparam
-							.throwSemanticException(
-									id + ": Actual parameter (" + aparam + ") is a scalar, but formal parameter is used like an array.");
-				}
-				// condition parameters appropriately
-				// (based on function parameter semantics)
-				if (aparam instanceof IDAst) {
-					IDAst aparamIdAst = (IDAst) aparam;
-					if (fparam.isScalar()) {
-						aparamIdAst.setScalar(true);
-					}
-					if (fparam.isArray()) {
+				if (fparam.isArray()) {
+					if (aparam instanceof IDAst) {
+						IDAst aparamIdAst = (IDAst) aparam;
+						if (aparamIdAst.isScalar()) {
+							aparam
+									.throwSemanticException(
+											id + ": Actual parameter (" + aparam
+													+ ") is a scalar, but formal parameter is used like an array.");
+						}
 						aparamIdAst.setArray(true);
+					} else if (!(aparam instanceof ArrayReferenceAst)) {
+						aparam
+								.throwSemanticException(
+										id + ": Actual parameter (" + aparam + ") is not an array or subarray reference.");
 					}
+				} else if (fparam.isScalar() && aparam instanceof IDAst) {
+					IDAst aparamIdAst = (IDAst) aparam;
+					if (aparamIdAst.isArray()) {
+						aparam
+								.throwSemanticException(
+										id + ": Actual parameter (" + aparam
+												+ ") is an array, but formal parameter is used like a scalar.");
+					}
+					aparamIdAst.setScalar(true);
 				}
 				// next
 				aPtr = aPtr.getAst2();
@@ -3819,7 +3879,11 @@ public class AwkParser {
 			if (getAst1() == null) {
 				actualParamCountLocal = 0;
 			} else {
-				actualParamCountLocal = getAst1().populateTuples(tuples);
+				actualParamCountLocal = populateActualParameters(
+						tuples,
+						(FunctionCallParamListAst) getAst1(),
+						collectArrayParameterIndexes(functionProxy.functionDefAst),
+						0);
 			}
 			int formalParamCount = functionProxy.getFunctionParamCount();
 			if (formalParamCount < actualParamCountLocal) {
@@ -3994,8 +4058,24 @@ public class AwkParser {
 					throw new SemanticException("sub needs at least 2 arguments");
 				}
 				boolean isGsub = fIdx == BUILTIN_FUNC_NAMES.get("gsub");
+				int numargs = 0;
+				for (AST paramPtr = getAst1(); paramPtr != null; paramPtr = paramPtr.getAst2()) {
+					numargs++;
+				}
+				if (numargs != 2 && numargs != 3) {
+					throw new SemanticException("sub requires 2 or 3 arguments, not " + numargs);
+				}
 
-				int numargs = getAst1().populateTuples(tuples);
+				getAst1().getAst1().populateTuples(tuples);
+				getAst1().getAst2().getAst1().populateTuples(tuples);
+				if (numargs == 3) {
+					AST targetAst = getAst1().getAst2().getAst2().getAst1();
+					if (targetAst instanceof ArrayReferenceAst) {
+						((ArrayReferenceAst) targetAst).populateTargetValueTuples(tuples);
+					} else {
+						targetAst.populateTuples(tuples);
+					}
+				}
 
 				// stack contains arg1,arg2[,arg3] - in that pop() order
 
@@ -4012,13 +4092,15 @@ public class AwkParser {
 						tuples.subForVariable(idAst.offset, idAst.isGlobal, isGsub);
 					} else if (ptr instanceof ArrayReferenceAst) {
 						ArrayReferenceAst arrAst = (ArrayReferenceAst) ptr;
-						// push the index
-						arrAst.getAst2().populateTuples(tuples);
-						IDAst idAst = (IDAst) arrAst.getAst1();
-						if (idAst.isScalar()) {
-							throw new SemanticException("Cannot use " + idAst + " as an array.");
+						if (arrAst.getAst1() instanceof IDAst) {
+							IDAst idAst = (IDAst) arrAst.getAst1();
+							if (idAst.isScalar()) {
+								throw new SemanticException("Cannot use " + idAst + " as an array.");
+							}
+							idAst.setArray(true);
 						}
-						tuples.subForArrayReference(idAst.offset, idAst.isGlobal, isGsub);
+						arrAst.populateTargetReferenceTuples(tuples);
+						tuples.subForMapReference(isGsub);
 					} else if (ptr instanceof DollarExpressionAst) {
 						// push the field ref
 						DollarExpressionAst dollarExpr = (DollarExpressionAst) ptr;
@@ -4041,18 +4123,33 @@ public class AwkParser {
 					throw new SemanticException("split needs at least 2 arguments");
 				}
 				AST ptr = getAst1().getAst2().getAst1();
-				if (!(ptr instanceof IDAst)) {
-					throw new SemanticException("split needs an array name as its 2nd argument");
+				if (!(ptr instanceof IDAst) && !(ptr instanceof ArrayReferenceAst)) {
+					throw new SemanticException("split needs an array or subarray reference as its 2nd argument");
 				}
-				IDAst arrAst = (IDAst) ptr;
-				if (arrAst.isScalar()) {
-					throw new SemanticException("split's 2nd arg cannot be a scalar");
+				if (ptr instanceof IDAst) {
+					IDAst arrAst = (IDAst) ptr;
+					if (arrAst.isScalar()) {
+						throw new SemanticException("split's 2nd arg cannot be a scalar");
+					}
+					arrAst.setArray(true);
 				}
-				arrAst.setArray(true);
 
-				int ast1Result = getAst1().populateTuples(tuples);
+				int ast1Result = 0;
+				for (AST paramPtr = getAst1(); paramPtr != null; paramPtr = paramPtr.getAst2()) {
+					ast1Result++;
+				}
 				if (ast1Result != 2 && ast1Result != 3) {
 					throw new SemanticException("split requires 2 or 3 arguments, not " + ast1Result);
+				}
+
+				getAst1().getAst1().populateTuples(tuples);
+				populateArrayOperandTuples(
+						ptr,
+						tuples,
+						true,
+						"split's 2nd arg must be an array or subarray reference");
+				if (ast1Result == 3) {
+					getAst1().getAst2().getAst2().getAst1().populateTuples(tuples);
 				}
 				tuples.split(ast1Result);
 				popSourceLineNumber(tuples);
@@ -4304,6 +4401,41 @@ public class AwkParser {
 			popSourceLineNumber(tuples);
 			return 1;
 		}
+
+		private void populateTargetReferenceTuples(AwkTuples tuples) {
+			pushSourceLineNumber(tuples);
+			populateContainerTuples(tuples);
+			getAst2().populateTuples(tuples);
+			popSourceLineNumber(tuples);
+		}
+
+		private void populateArrayValueTuples(AwkTuples tuples, boolean createIfMissing) {
+			pushSourceLineNumber(tuples);
+			populateContainerTuples(tuples);
+			getAst2().populateTuples(tuples);
+			if (createIfMissing) {
+				tuples.ensureArrayElement();
+			} else {
+				tuples.dereferenceArray();
+			}
+			popSourceLineNumber(tuples);
+		}
+
+		private void populateTargetValueTuples(AwkTuples tuples) {
+			pushSourceLineNumber(tuples);
+			populateContainerTuples(tuples);
+			getAst2().populateTuples(tuples);
+			tuples.dereferenceArray();
+			popSourceLineNumber(tuples);
+		}
+
+		private void populateContainerTuples(AwkTuples tuples) {
+			if (getAst1() instanceof ArrayReferenceAst) {
+				((ArrayReferenceAst) getAst1()).populateArrayValueTuples(tuples, true);
+			} else {
+				getAst1().populateTuples(tuples);
+			}
+		}
 	}
 
 	private final class IntegerAst extends ScalarExpressionAst {
@@ -4473,9 +4605,15 @@ public class AwkParser {
 				tuples.inc(idAst.offset, idAst.isGlobal);
 			} else if (getAst1() instanceof ArrayReferenceAst) {
 				ArrayReferenceAst arrAst = (ArrayReferenceAst) getAst1();
-				IDAst idAst = (IDAst) arrAst.getAst1();
-				arrAst.getAst2().populateTuples(tuples);
-				tuples.incArrayRef(idAst.offset, idAst.isGlobal);
+				if (arrAst.getAst1() instanceof IDAst) {
+					IDAst idAst = (IDAst) arrAst.getAst1();
+					if (idAst.isScalar()) {
+						throw new SemanticException("Cannot use " + idAst + " as an array.");
+					}
+					idAst.setArray(true);
+				}
+				arrAst.populateTargetReferenceTuples(tuples);
+				tuples.incMapRef();
 			} else if (getAst1() instanceof DollarExpressionAst) {
 				DollarExpressionAst dollarExpr = (DollarExpressionAst) getAst1();
 				dollarExpr.getAst1().populateTuples(tuples); // OPTIMIATION: duplicate the x in $x here
@@ -4515,9 +4653,15 @@ public class AwkParser {
 				tuples.dec(idAst.offset, idAst.isGlobal);
 			} else if (getAst1() instanceof ArrayReferenceAst) {
 				ArrayReferenceAst arrAst = (ArrayReferenceAst) getAst1();
-				IDAst idAst = (IDAst) arrAst.getAst1();
-				arrAst.getAst2().populateTuples(tuples);
-				tuples.decArrayRef(idAst.offset, idAst.isGlobal);
+				if (arrAst.getAst1() instanceof IDAst) {
+					IDAst idAst = (IDAst) arrAst.getAst1();
+					if (idAst.isScalar()) {
+						throw new SemanticException("Cannot use " + idAst + " as an array.");
+					}
+					idAst.setArray(true);
+				}
+				arrAst.populateTargetReferenceTuples(tuples);
+				tuples.decMapRef();
 			} else if (getAst1() instanceof DollarExpressionAst) {
 				DollarExpressionAst dollarExpr = (DollarExpressionAst) getAst1();
 				dollarExpr.getAst1().populateTuples(tuples); // OPTIMIATION: duplicate the x in $x here
@@ -4555,15 +4699,25 @@ public class AwkParser {
 				dollarExpr.getAst1().populateTuples(tuples);
 				tuples.incDollarRef();
 			} else {
-				getAst1().populateTuples(tuples);
+				if (getAst1() instanceof ArrayReferenceAst) {
+					((ArrayReferenceAst) getAst1()).populateTargetValueTuples(tuples);
+				} else {
+					getAst1().populateTuples(tuples);
+				}
 				if (getAst1() instanceof IDAst) {
 					IDAst idAst = (IDAst) getAst1();
 					tuples.postInc(idAst.offset, idAst.isGlobal);
 				} else if (getAst1() instanceof ArrayReferenceAst) {
 					ArrayReferenceAst arrAst = (ArrayReferenceAst) getAst1();
-					IDAst idAst = (IDAst) arrAst.getAst1();
-					arrAst.getAst2().populateTuples(tuples);
-					tuples.incArrayRef(idAst.offset, idAst.isGlobal);
+					if (arrAst.getAst1() instanceof IDAst) {
+						IDAst idAst = (IDAst) arrAst.getAst1();
+						if (idAst.isScalar()) {
+							throw new SemanticException("Cannot use " + idAst + " as an array.");
+						}
+						idAst.setArray(true);
+					}
+					arrAst.populateTargetReferenceTuples(tuples);
+					tuples.incMapRef();
 				} else {
 					throw new NotImplementedError("unhandled postinc for " + getAst1());
 				}
@@ -4582,15 +4736,25 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			getAst1().populateTuples(tuples);
+			if (getAst1() instanceof ArrayReferenceAst) {
+				((ArrayReferenceAst) getAst1()).populateTargetValueTuples(tuples);
+			} else {
+				getAst1().populateTuples(tuples);
+			}
 			if (getAst1() instanceof IDAst) {
 				IDAst idAst = (IDAst) getAst1();
 				tuples.postDec(idAst.offset, idAst.isGlobal);
 			} else if (getAst1() instanceof ArrayReferenceAst) {
 				ArrayReferenceAst arrAst = (ArrayReferenceAst) getAst1();
-				IDAst idAst = (IDAst) arrAst.getAst1();
-				arrAst.getAst2().populateTuples(tuples);
-				tuples.decArrayRef(idAst.offset, idAst.isGlobal);
+				if (arrAst.getAst1() instanceof IDAst) {
+					IDAst idAst = (IDAst) arrAst.getAst1();
+					if (idAst.isScalar()) {
+						throw new SemanticException("Cannot use " + idAst + " as an array.");
+					}
+					idAst.setArray(true);
+				}
+				arrAst.populateTargetReferenceTuples(tuples);
+				tuples.decMapRef();
 			} else if (getAst1() instanceof DollarExpressionAst) {
 				DollarExpressionAst dollarExpr = (DollarExpressionAst) getAst1();
 				dollarExpr.getAst1().populateTuples(tuples);
@@ -4676,13 +4840,11 @@ public class AwkParser {
 			if (getAst1() == null) {
 				paramCount = 0;
 			} else {
+				Set<Integer> arrayIndexes = new HashSet<Integer>();
 				for (int idx : reqArrayIdxs) {
-					AST paramAst = getParamAst((FunctionCallParamListAst) getAst1(), idx);
-					// if the parameter is an IDAst...
-					if (paramAst.getAst1() instanceof IDAst) {
-						// then force it to be an array,
-						// or complain if it is already tagged as a scalar
-						IDAst idAst = (IDAst) paramAst.getAst1();
+					AST paramAst = getParamAst((FunctionCallParamListAst) getAst1(), idx).getAst1();
+					if (paramAst instanceof IDAst) {
+						IDAst idAst = (IDAst) paramAst;
 						if (idAst.isScalar()) {
 							throw new SemanticException(
 									"Extension '"
@@ -4692,10 +4854,17 @@ public class AwkParser {
 											+ " be an associative array, not a scalar.");
 						}
 						idAst.setArray(true);
+						arrayIndexes.add(Integer.valueOf(idx));
+					} else if (paramAst instanceof ArrayReferenceAst) {
+						arrayIndexes.add(Integer.valueOf(idx));
 					}
 				}
 
-				paramCount = getAst1().populateTuples(tuples);
+				paramCount = populateActualParameters(
+						tuples,
+						(FunctionCallParamListAst) getAst1(),
+						arrayIndexes,
+						0);
 			}
 			// isInitial == true ::
 			// retval of this extension is not a function parameter
@@ -4823,10 +4992,15 @@ public class AwkParser {
 				}
 			} else if (getAst2() instanceof ArrayReferenceAst) {
 				ArrayReferenceAst arr = (ArrayReferenceAst) getAst2();
-				// push the index
-				arr.getAst2().populateTuples(tuples); // push the array ref itself
-				IDAst idAst = (IDAst) arr.getAst1();
-				tuples.assignArray(idAst.offset, idAst.isGlobal);
+				if (arr.getAst1() instanceof IDAst) {
+					IDAst idAst = (IDAst) arr.getAst1();
+					if (idAst.isScalar()) {
+						throw new SemanticException("Cannot use " + idAst + " as an array.");
+					}
+					idAst.setArray(true);
+				}
+				arr.populateTargetReferenceTuples(tuples);
+				tuples.assignMapElement();
 			} else if (getAst2() instanceof DollarExpressionAst) {
 				DollarExpressionAst dollarExpr = (DollarExpressionAst) getAst2();
 				if (dollarExpr.getAst2() != null) {
@@ -4899,13 +5073,16 @@ public class AwkParser {
 			pushSourceLineNumber(tuples);
 
 			if (getAst1() instanceof ArrayReferenceAst) {
-				IDAst idAst = (IDAst) getAst1().getAst1();
-				if (idAst.isScalar()) {
-					throw new SemanticException("delete: Cannot use a scalar as an array.");
+				ArrayReferenceAst arrAst = (ArrayReferenceAst) getAst1();
+				if (arrAst.getAst1() instanceof IDAst) {
+					IDAst idAst = (IDAst) arrAst.getAst1();
+					if (idAst.isScalar()) {
+						throw new SemanticException("delete: Cannot use a scalar as an array.");
+					}
+					idAst.setArray(true);
 				}
-				idAst.setArray(true);
-				getAst1().getAst2().populateTuples(tuples); // idx on the stack
-				tuples.deleteArrayElement(idAst.offset, idAst.isGlobal);
+				arrAst.populateTargetReferenceTuples(tuples);
+				tuples.deleteMapElement();
 			} else if (getAst1() instanceof IDAst) {
 				IDAst idAst = (IDAst) getAst1();
 				if (idAst.isScalar()) {

--- a/src/main/java/io/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/io/jawk/intermediate/AwkTuples.java
@@ -328,6 +328,13 @@ public class AwkTuples implements Serializable {
 	}
 
 	/**
+	 * Assigns a value to a stack-provided associative-array element.
+	 */
+	public void assignMapElement() {
+		queue.add(new Tuple(Opcode.ASSIGN_MAP_ELEMENT));
+	}
+
+	/**
 	 * <p>
 	 * assignAsInput.
 	 * </p>
@@ -452,6 +459,13 @@ public class AwkTuples implements Serializable {
 	}
 
 	/**
+	 * Applies {@code +=} to a stack-provided associative-array element.
+	 */
+	public void plusEqMapElement() {
+		queue.add(new Tuple(Opcode.PLUS_EQ_MAP_ELEMENT));
+	}
+
+	/**
 	 * <p>
 	 * minusEqArray.
 	 * </p>
@@ -461,6 +475,13 @@ public class AwkTuples implements Serializable {
 	 */
 	public void minusEqArray(int offset, boolean isGlobal) {
 		queue.add(new Tuple(Opcode.MINUS_EQ_ARRAY, offset, isGlobal));
+	}
+
+	/**
+	 * Applies {@code -=} to a stack-provided associative-array element.
+	 */
+	public void minusEqMapElement() {
+		queue.add(new Tuple(Opcode.MINUS_EQ_MAP_ELEMENT));
 	}
 
 	/**
@@ -476,6 +497,13 @@ public class AwkTuples implements Serializable {
 	}
 
 	/**
+	 * Applies {@code *=} to a stack-provided associative-array element.
+	 */
+	public void multEqMapElement() {
+		queue.add(new Tuple(Opcode.MULT_EQ_MAP_ELEMENT));
+	}
+
+	/**
 	 * <p>
 	 * divEqArray.
 	 * </p>
@@ -485,6 +513,13 @@ public class AwkTuples implements Serializable {
 	 */
 	public void divEqArray(int offset, boolean isGlobal) {
 		queue.add(new Tuple(Opcode.DIV_EQ_ARRAY, offset, isGlobal));
+	}
+
+	/**
+	 * Applies {@code /=} to a stack-provided associative-array element.
+	 */
+	public void divEqMapElement() {
+		queue.add(new Tuple(Opcode.DIV_EQ_MAP_ELEMENT));
 	}
 
 	/**
@@ -500,6 +535,13 @@ public class AwkTuples implements Serializable {
 	}
 
 	/**
+	 * Applies {@code %=} to a stack-provided associative-array element.
+	 */
+	public void modEqMapElement() {
+		queue.add(new Tuple(Opcode.MOD_EQ_MAP_ELEMENT));
+	}
+
+	/**
 	 * <p>
 	 * powEqArray.
 	 * </p>
@@ -509,6 +551,14 @@ public class AwkTuples implements Serializable {
 	 */
 	public void powEqArray(int offset, boolean isGlobal) {
 		queue.add(new Tuple(Opcode.POW_EQ_ARRAY, offset, isGlobal));
+	}
+
+	/**
+	 * Applies exponentiation assignment to a stack-provided associative-array
+	 * element.
+	 */
+	public void powEqMapElement() {
+		queue.add(new Tuple(Opcode.POW_EQ_MAP_ELEMENT));
 	}
 
 	/**
@@ -715,6 +765,16 @@ public class AwkTuples implements Serializable {
 	}
 
 	/**
+	 * Applies {@code sub}/{@code gsub} to a stack-provided associative-array
+	 * element.
+	 *
+	 * @param isGsub {@code true} for {@code gsub}, {@code false} for {@code sub}
+	 */
+	public void subForMapReference(boolean isGsub) {
+		queue.add(new Tuple(Opcode.SUB_FOR_MAP_REFERENCE, isGsub));
+	}
+
+	/**
 	 * <p>
 	 * split.
 	 * </p>
@@ -887,6 +947,13 @@ public class AwkTuples implements Serializable {
 	}
 
 	/**
+	 * Increments a stack-provided associative-array element reference.
+	 */
+	public void incMapRef() {
+		queue.add(new Tuple(Opcode.INC_MAP_REF));
+	}
+
+	/**
 	 * <p>
 	 * decArrayRef.
 	 * </p>
@@ -896,6 +963,13 @@ public class AwkTuples implements Serializable {
 	 */
 	public void decArrayRef(int offset, boolean isGlobal) {
 		queue.add(new Tuple(Opcode.DEC_ARRAY_REF, offset, isGlobal));
+	}
+
+	/**
+	 * Decrements a stack-provided associative-array element reference.
+	 */
+	public void decMapRef() {
+		queue.add(new Tuple(Opcode.DEC_MAP_REF));
 	}
 
 	/**
@@ -995,6 +1069,14 @@ public class AwkTuples implements Serializable {
 	 */
 	public void dereferenceArray() {
 		queue.add(new Tuple(Opcode.DEREF_ARRAY));
+	}
+
+	/**
+	 * Dereferences an associative-array element as a nested array, creating it if
+	 * needed.
+	 */
+	public void ensureArrayElement() {
+		queue.add(new Tuple(Opcode.ENSURE_ARRAY_ELEMENT));
 	}
 
 	/**
@@ -1524,6 +1606,13 @@ public class AwkTuples implements Serializable {
 	 */
 	public void deleteArrayElement(int offset, boolean isGlobal) {
 		queue.add(new Tuple(Opcode.DELETE_ARRAY_ELEMENT, offset, isGlobal));
+	}
+
+	/**
+	 * Deletes a stack-provided associative-array element.
+	 */
+	public void deleteMapElement() {
+		queue.add(new Tuple(Opcode.DELETE_MAP_ELEMENT));
 	}
 
 	/**

--- a/src/main/java/io/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/io/jawk/intermediate/AwkTuples.java
@@ -149,13 +149,6 @@ public class AwkTuples implements Serializable {
 	}
 
 	/**
-	 * Replaces a blank or uninitialized top-of-stack value with numeric zero.
-	 */
-	public void blankToZero() {
-		queue.add(new Tuple(Opcode.BLANK_TO_ZERO));
-	}
-
-	/**
 	 * <p>
 	 * ifTrue.
 	 * </p>
@@ -1076,6 +1069,14 @@ public class AwkTuples implements Serializable {
 	 */
 	public void dereferenceArray() {
 		queue.add(new Tuple(Opcode.DEREF_ARRAY));
+	}
+
+	/**
+	 * Looks up an associative-array element without creating a blank entry when
+	 * the key is missing.
+	 */
+	public void peekArrayElement() {
+		queue.add(new Tuple(Opcode.PEEK_ARRAY_ELEMENT));
 	}
 
 	/**

--- a/src/main/java/io/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/io/jawk/intermediate/AwkTuples.java
@@ -149,6 +149,13 @@ public class AwkTuples implements Serializable {
 	}
 
 	/**
+	 * Replaces a blank or uninitialized top-of-stack value with numeric zero.
+	 */
+	public void blankToZero() {
+		queue.add(new Tuple(Opcode.BLANK_TO_ZERO));
+	}
+
+	/**
 	 * <p>
 	 * ifTrue.
 	 * </p>

--- a/src/main/java/io/jawk/intermediate/Opcode.java
+++ b/src/main/java/io/jawk/intermediate/Opcode.java
@@ -218,6 +218,14 @@ public enum Opcode {
 	 */
 	ASSIGN_ARRAY,
 	/**
+	 * Assigns an item to an element of the associative array currently on the stack.
+	 * The item remains on the stack.
+	 * <p>
+	 * Stack before: associative-array array-index item ...<br/>
+	 * Stack after: item ...
+	 */
+	ASSIGN_MAP_ELEMENT,
+	/**
 	 * Assigns the top-of-stack to $0. The contents of the stack are unaffected.
 	 * Upon assignment, individual field variables are recalculated.
 	 * <p>
@@ -392,6 +400,60 @@ public enum Opcode {
 	 * Stack after: x^n ...
 	 */
 	POW_EQ_ARRAY,
+	/**
+	 * Increase the contents of a stack-provided associative-array element by an
+	 * adjustment value; assigns the result to the array and pushes the result onto
+	 * the stack.
+	 * <p>
+	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack after: x+n ...
+	 */
+	PLUS_EQ_MAP_ELEMENT,
+	/**
+	 * Decreases the contents of a stack-provided associative-array element by an
+	 * adjustment value; assigns the result to the array and pushes the result onto
+	 * the stack.
+	 * <p>
+	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack after: x-n ...
+	 */
+	MINUS_EQ_MAP_ELEMENT,
+	/**
+	 * Multiplies the contents of a stack-provided associative-array element by an
+	 * adjustment value; assigns the result to the array and pushes the result onto
+	 * the stack.
+	 * <p>
+	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack after: x*n ...
+	 */
+	MULT_EQ_MAP_ELEMENT,
+	/**
+	 * Divides the contents of a stack-provided associative-array element by an
+	 * adjustment value; assigns the result to the array and pushes the result onto
+	 * the stack.
+	 * <p>
+	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack after: x/n ...
+	 */
+	DIV_EQ_MAP_ELEMENT,
+	/**
+	 * Takes the modulus of the contents of a stack-provided associative-array
+	 * element by an adjustment value; assigns the result to the array and pushes the
+	 * result onto the stack.
+	 * <p>
+	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack after: x%n ...
+	 */
+	MOD_EQ_MAP_ELEMENT,
+	/**
+	 * Raises the contents of a stack-provided associative-array element to the
+	 * power of an adjustment value; assigns the result to the array and pushes the
+	 * result onto the stack.
+	 * <p>
+	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack after: x^n ...
+	 */
+	POW_EQ_MAP_ELEMENT,
 	/**
 	 * Increases the contents of an input field by an adjustment value;
 	 * assigns the result to the input field and pushes the result onto the stack.
@@ -593,6 +655,16 @@ public enum Opcode {
 	 */
 	SUB_FOR_ARRAY_REFERENCE,
 	/**
+	 * Built-in function that substitutes an occurrence (or all occurrences) of a
+	 * string in a particular stack-provided array cell and replaces it with another.
+	 * <p>
+	 * Argument 1: is global sub
+	 * <p>
+	 * Stack before: associative-array array-index regexp replacement-string orig-string ...<br/>
+	 * Stack after: ...
+	 */
+	SUB_FOR_MAP_REFERENCE,
+	/**
 	 * Built-in function to split a string by a regexp and put the
 	 * components into an array.
 	 * <p>
@@ -758,6 +830,20 @@ public enum Opcode {
 	 */
 	DEC_ARRAY_REF,
 	/**
+	 * Increases the stack-provided array element reference by one.
+	 * <p>
+	 * Stack before: associative-array array-idx ...<br/>
+	 * Stack after: x+1 ...
+	 */
+	INC_MAP_REF,
+	/**
+	 * Decreases the stack-provided array element reference by one.
+	 * <p>
+	 * Stack before: associative-array array-idx ...<br/>
+	 * Stack after: x-1 ...
+	 */
+	DEC_MAP_REF,
+	/**
 	 * Increases the input field variable by one; pushes the result
 	 * onto the stack.
 	 * <p>
@@ -830,6 +916,14 @@ public enum Opcode {
 
 	/** Constant <code>DEREF_ARRAY=336</code> */
 	DEREF_ARRAY,
+	/**
+	 * Dereferences an associative-array element as an array, creating a nested
+	 * array when the element is currently blank or uninitialized.
+	 * <p>
+	 * Stack before: associative-array array-index ...<br/>
+	 * Stack after: nested-associative-array ...
+	 */
+	ENSURE_ARRAY_ELEMENT,
 
 	// for (x in y) {keyset} support
 	/**
@@ -1148,6 +1242,13 @@ public enum Opcode {
 	 * Stack after: ...
 	 */
 	DELETE_ARRAY_ELEMENT,
+	/**
+	 * Deletes an entry in a stack-provided associative array.
+	 * <p>
+	 * Stack before: associative-array array-index <br/>
+	 * Stack after: ...
+	 */
+	DELETE_MAP_ELEMENT,
 
 	/**
 	 * Internal.

--- a/src/main/java/io/jawk/intermediate/Opcode.java
+++ b/src/main/java/io/jawk/intermediate/Opcode.java
@@ -75,6 +75,14 @@ public enum Opcode {
 	 */
 	TO_NUMBER,
 	/**
+	 * Replaces a blank or uninitialized top-of-stack value with numeric zero.
+	 * Non-blank values remain unchanged.
+	 * <p>
+	 * Stack before: x ...<br/>
+	 * Stack after: x (or 0 when blank) ...
+	 */
+	BLANK_TO_ZERO,
+	/**
 	 * Pops and evaluates the top-of-stack; if
 	 * true, it jumps to a specified address.
 	 * <p>

--- a/src/main/java/io/jawk/intermediate/Opcode.java
+++ b/src/main/java/io/jawk/intermediate/Opcode.java
@@ -221,7 +221,7 @@ public enum Opcode {
 	 * Assigns an item to an element of the associative array currently on the stack.
 	 * The item remains on the stack.
 	 * <p>
-	 * Stack before: associative-array array-index item ...<br/>
+	 * Stack before: array-index associative-array item ...<br/>
 	 * Stack after: item ...
 	 */
 	ASSIGN_MAP_ELEMENT,
@@ -405,7 +405,7 @@ public enum Opcode {
 	 * adjustment value; assigns the result to the array and pushes the result onto
 	 * the stack.
 	 * <p>
-	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack before: array-idx associative-array n ...<br/>
 	 * Stack after: x+n ...
 	 */
 	PLUS_EQ_MAP_ELEMENT,
@@ -414,7 +414,7 @@ public enum Opcode {
 	 * adjustment value; assigns the result to the array and pushes the result onto
 	 * the stack.
 	 * <p>
-	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack before: array-idx associative-array n ...<br/>
 	 * Stack after: x-n ...
 	 */
 	MINUS_EQ_MAP_ELEMENT,
@@ -423,7 +423,7 @@ public enum Opcode {
 	 * adjustment value; assigns the result to the array and pushes the result onto
 	 * the stack.
 	 * <p>
-	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack before: array-idx associative-array n ...<br/>
 	 * Stack after: x*n ...
 	 */
 	MULT_EQ_MAP_ELEMENT,
@@ -432,7 +432,7 @@ public enum Opcode {
 	 * adjustment value; assigns the result to the array and pushes the result onto
 	 * the stack.
 	 * <p>
-	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack before: array-idx associative-array n ...<br/>
 	 * Stack after: x/n ...
 	 */
 	DIV_EQ_MAP_ELEMENT,
@@ -441,7 +441,7 @@ public enum Opcode {
 	 * element by an adjustment value; assigns the result to the array and pushes the
 	 * result onto the stack.
 	 * <p>
-	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack before: array-idx associative-array n ...<br/>
 	 * Stack after: x%n ...
 	 */
 	MOD_EQ_MAP_ELEMENT,
@@ -450,7 +450,7 @@ public enum Opcode {
 	 * power of an adjustment value; assigns the result to the array and pushes the
 	 * result onto the stack.
 	 * <p>
-	 * Stack before: associative-array array-idx n ...<br/>
+	 * Stack before: array-idx associative-array n ...<br/>
 	 * Stack after: x^n ...
 	 */
 	POW_EQ_MAP_ELEMENT,
@@ -660,7 +660,7 @@ public enum Opcode {
 	 * <p>
 	 * Argument 1: is global sub
 	 * <p>
-	 * Stack before: associative-array array-index regexp replacement-string orig-string ...<br/>
+	 * Stack before: array-index associative-array orig-string replacement-string regexp ...<br/>
 	 * Stack after: ...
 	 */
 	SUB_FOR_MAP_REFERENCE,
@@ -832,14 +832,14 @@ public enum Opcode {
 	/**
 	 * Increases the stack-provided array element reference by one.
 	 * <p>
-	 * Stack before: associative-array array-idx ...<br/>
+	 * Stack before: array-idx associative-array ...<br/>
 	 * Stack after: x+1 ...
 	 */
 	INC_MAP_REF,
 	/**
 	 * Decreases the stack-provided array element reference by one.
 	 * <p>
-	 * Stack before: associative-array array-idx ...<br/>
+	 * Stack before: array-idx associative-array ...<br/>
 	 * Stack after: x-1 ...
 	 */
 	DEC_MAP_REF,
@@ -920,7 +920,7 @@ public enum Opcode {
 	 * Dereferences an associative-array element as an array, creating a nested
 	 * array when the element is currently blank or uninitialized.
 	 * <p>
-	 * Stack before: associative-array array-index ...<br/>
+	 * Stack before: array-index associative-array ...<br/>
 	 * Stack after: nested-associative-array ...
 	 */
 	ENSURE_ARRAY_ELEMENT,
@@ -1245,7 +1245,7 @@ public enum Opcode {
 	/**
 	 * Deletes an entry in a stack-provided associative array.
 	 * <p>
-	 * Stack before: associative-array array-index <br/>
+	 * Stack before: array-index associative-array <br/>
 	 * Stack after: ...
 	 */
 	DELETE_MAP_ELEMENT,

--- a/src/main/java/io/jawk/intermediate/Opcode.java
+++ b/src/main/java/io/jawk/intermediate/Opcode.java
@@ -75,14 +75,6 @@ public enum Opcode {
 	 */
 	TO_NUMBER,
 	/**
-	 * Replaces a blank or uninitialized top-of-stack value with numeric zero.
-	 * Non-blank values remain unchanged.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: x (or 0 when blank) ...
-	 */
-	BLANK_TO_ZERO,
-	/**
 	 * Pops and evaluates the top-of-stack; if
 	 * true, it jumps to a specified address.
 	 * <p>
@@ -924,14 +916,6 @@ public enum Opcode {
 
 	/** Constant <code>DEREF_ARRAY=336</code> */
 	DEREF_ARRAY,
-	/**
-	 * Dereferences an associative-array element as an array, creating a nested
-	 * array when the element is currently blank or uninitialized.
-	 * <p>
-	 * Stack before: array-index associative-array ...<br/>
-	 * Stack after: nested-associative-array ...
-	 */
-	ENSURE_ARRAY_ELEMENT,
 
 	// for (x in y) {keyset} support
 	/**
@@ -1451,7 +1435,25 @@ public enum Opcode {
 	 * Stack before: ...<br/>
 	 * Stack after: x ... or 0 if uninitialized
 	 */
-	POSTDEC;
+	POSTDEC,
+
+	/**
+	 * Dereferences an associative-array element as an array, creating a nested
+	 * array when the element is currently blank or uninitialized.
+	 * <p>
+	 * Stack before: array-index associative-array ...<br/>
+	 * Stack after: nested-associative-array ...
+	 */
+	ENSURE_ARRAY_ELEMENT,
+
+	/**
+	 * Looks up an associative-array element without creating a blank entry when
+	 * the key is missing.
+	 * <p>
+	 * Stack before: array-index associative-array ...<br/>
+	 * Stack after: item ...
+	 */
+	PEEK_ARRAY_ELEMENT;
 
 	private static final Opcode[] VALUES = values();
 

--- a/src/main/java/io/jawk/util/AwkSettings.java
+++ b/src/main/java/io/jawk/util/AwkSettings.java
@@ -85,7 +85,8 @@ public class AwkSettings {
 	private volatile boolean useSortedArrayKeys = false;
 
 	/**
-	 * Whether to accept gawk-style arrays of arrays syntax such as {@code a[i][j]}.
+	 * Whether to accept gawk-style arrays of arrays syntax such as {@code a[i][j]}
+	 * and subarray operands in array-only positions such as {@code split(..., a[i])}.
 	 * <code>true</code> by default.
 	 */
 	private volatile boolean allowArraysOfArrays = true;
@@ -278,7 +279,8 @@ public class AwkSettings {
 	}
 
 	/**
-	 * Whether to accept gawk-style arrays of arrays syntax such as {@code a[i][j]}.
+	 * Whether to accept gawk-style arrays of arrays syntax such as {@code a[i][j]}
+	 * and subarray operands in array-only positions such as {@code split(..., a[i])}.
 	 *
 	 * @return {@code true} when arrays of arrays are enabled at compile time
 	 */
@@ -288,9 +290,10 @@ public class AwkSettings {
 
 	/**
 	 * Enables or disables gawk-style arrays of arrays syntax such as
-	 * {@code a[i][j]}.
+	 * {@code a[i][j]} and subarray operands in array-only positions such as
+	 * {@code split(..., a[i])} or {@code for (k in a[i])}.
 	 *
-	 * @param allowArraysOfArrays {@code true} to accept arrays-of-arrays syntax
+	 * @param allowArraysOfArrays {@code true} to accept arrays-of-arrays features
 	 */
 	public void setAllowArraysOfArrays(boolean allowArraysOfArrays) {
 		this.allowArraysOfArrays = allowArraysOfArrays;

--- a/src/main/java/io/jawk/util/AwkSettings.java
+++ b/src/main/java/io/jawk/util/AwkSettings.java
@@ -85,6 +85,12 @@ public class AwkSettings {
 	private volatile boolean useSortedArrayKeys = false;
 
 	/**
+	 * Whether to accept gawk-style arrays of arrays syntax such as {@code a[i][j]}.
+	 * <code>true</code> by default.
+	 */
+	private volatile boolean allowArraysOfArrays = true;
+
+	/**
 	 * Locale for the output of numbers
 	 * <code>US-English</code> by default.
 	 */
@@ -119,6 +125,7 @@ public class AwkSettings {
 		desc.append("variables = ").append(getVariables()).append(newLine);
 		desc.append("fieldSeparator = ").append(getFieldSeparator()).append(newLine);
 		desc.append("useSortedArrayKeys = ").append(isUseSortedArrayKeys()).append(newLine);
+		desc.append("allowArraysOfArrays = ").append(isAllowArraysOfArrays()).append(newLine);
 		return desc.toString();
 	}
 
@@ -135,6 +142,9 @@ public class AwkSettings {
 
 		if (isUseSortedArrayKeys()) {
 			extensions.append(", associative array keys are sorted");
+		}
+		if (isAllowArraysOfArrays()) {
+			extensions.append(", arrays of arrays");
 		}
 		if (extensions.length() > 0) {
 			return "{extensions: " + extensions.substring(2) + "}";
@@ -268,6 +278,26 @@ public class AwkSettings {
 	}
 
 	/**
+	 * Whether to accept gawk-style arrays of arrays syntax such as {@code a[i][j]}.
+	 *
+	 * @return {@code true} when arrays of arrays are enabled at compile time
+	 */
+	public boolean isAllowArraysOfArrays() {
+		return allowArraysOfArrays;
+	}
+
+	/**
+	 * Enables or disables gawk-style arrays of arrays syntax such as
+	 * {@code a[i][j]}.
+	 *
+	 * @param allowArraysOfArrays {@code true} to accept arrays-of-arrays syntax
+	 */
+	public void setAllowArraysOfArrays(boolean allowArraysOfArrays) {
+		this.allowArraysOfArrays = allowArraysOfArrays;
+		markModified();
+	}
+
+	/**
 	 * <p>
 	 * Getter for the field <code>locale</code>.
 	 * </p>
@@ -336,6 +366,11 @@ public class AwkSettings {
 
 		@Override
 		public void setUseSortedArrayKeys(boolean useSortedArrayKeys) {
+			throw unsupported();
+		}
+
+		@Override
+		public void setAllowArraysOfArrays(boolean allowArraysOfArrays) {
 			throw unsupported();
 		}
 

--- a/src/site/markdown/compatibility.md
+++ b/src/site/markdown/compatibility.md
@@ -14,6 +14,7 @@ Jawk keeps the AWK language model while adding JVM-oriented capabilities:
 - it runs entirely in Java and can be embedded directly in applications
 - it exposes a serializable tuple representation for compilation and reuse
 - it can maintain associative array keys in sorted order
+- it supports gawk-style arrays of arrays (`a[i][j]`) in addition to classic AWK multi-dimensional subscripts (`a[i, j]`)
 - it supports explicit extensions
 - it offers a sandboxed compiler and runtime
 

--- a/src/site/markdown/compatibility.md
+++ b/src/site/markdown/compatibility.md
@@ -15,6 +15,7 @@ Jawk keeps the AWK language model while adding JVM-oriented capabilities:
 - it exposes a serializable tuple representation for compilation and reuse
 - it can maintain associative array keys in sorted order
 - it supports gawk-style arrays of arrays (`a[i][j]`) in addition to classic AWK multi-dimensional subscripts (`a[i, j]`)
+  This compile-time feature can be disabled, in which case Jawk also rejects subarray operands in array-only positions such as `split(..., a[i])` or `for (k in a[i])`.
 - it supports explicit extensions
 - it offers a sandboxed compiler and runtime
 

--- a/src/site/markdown/java-compile.md
+++ b/src/site/markdown/java-compile.md
@@ -66,6 +66,16 @@ awk.script(program)
 
 This keeps compilation and execution separate, which is useful when the same AWK program is reused across multiple inputs.
 
+Compilation settings matter here. For example, gawk-style arrays of arrays (`a[i][j]`) are accepted by default, but you can disable that syntax before compiling:
+
+```java
+AwkSettings settings = new AwkSettings();
+settings.setAllowArraysOfArrays(false);
+
+Awk awk = new Awk(settings);
+AwkProgram program = awk.compile("{ print a[1,2] }");
+```
+
 ## Choosing the Right Reuse Strategy
 
 - Use `eval(String...)` when the expression is cheap and called only occasionally.

--- a/src/site/markdown/java-compile.md
+++ b/src/site/markdown/java-compile.md
@@ -66,7 +66,7 @@ awk.script(program)
 
 This keeps compilation and execution separate, which is useful when the same AWK program is reused across multiple inputs.
 
-Compilation settings matter here. For example, gawk-style arrays of arrays (`a[i][j]`) are accepted by default, but you can disable that syntax before compiling:
+Compilation settings matter here. For example, gawk-style arrays of arrays (`a[i][j]`) are accepted by default, but you can disable that compile-time mode before compiling. When disabled, Jawk also rejects subarray operands in array-only positions such as `split(..., a[i])` or `for (k in a[i])`:
 
 ```java
 AwkSettings settings = new AwkSettings();

--- a/src/site/markdown/java.md
+++ b/src/site/markdown/java.md
@@ -36,14 +36,14 @@ Awk awk = new Awk(settings);
 | `setLocale(Locale)` | `Locale.US` | Locale for numeric output formatting |
 | `setDefaultRS(String)` | Platform line separator | Default value for `RS`, the record separator  |
 | `setUseSortedArrayKeys(boolean)` | `false` | Whether to keep associative array keys in sorted order |
-| `setAllowArraysOfArrays(boolean)` | `true` | Whether the compiler accepts gawk-style nested array syntax such as `a[i][j]` |
+| `setAllowArraysOfArrays(boolean)` | `true` | Whether the compiler accepts gawk-style nested array features such as `a[i][j]` and `split(..., a[i])` |
 | `putVariable(String, Object)` | Empty map | Pre-set variables available before `BEGIN` |
 
 Output destination is specified per-call on the builder (`execute()`, `execute(PrintStream)`, `execute(OutputStream)`, `execute(Appendable)`, or `execute(AwkSink)`). See the [Custom Output](java-output.html) guide for details.
 
 For more on passing variables to scripts, see [Variables and Arguments](java-variables.html).
 
-By default, Jawk accepts both classic multi-dimensional array syntax (`a[i, j]`) and gawk-style arrays of arrays (`a[i][j]`). Disable the gawk-style parser mode when you need strict classic AWK parsing:
+By default, Jawk accepts both classic multi-dimensional array syntax (`a[i, j]`) and gawk-style arrays of arrays (`a[i][j]`). Disable this compile-time mode when you need strict classic AWK parsing; doing so also rejects subarray operands in array-only positions such as `split(..., a[i])`, `for (k in a[i])`, and `"x" in a[i]`:
 
 ```java
 AwkSettings settings = new AwkSettings();

--- a/src/site/markdown/java.md
+++ b/src/site/markdown/java.md
@@ -36,11 +36,21 @@ Awk awk = new Awk(settings);
 | `setLocale(Locale)` | `Locale.US` | Locale for numeric output formatting |
 | `setDefaultRS(String)` | Platform line separator | Default value for `RS`, the record separator  |
 | `setUseSortedArrayKeys(boolean)` | `false` | Whether to keep associative array keys in sorted order |
+| `setAllowArraysOfArrays(boolean)` | `true` | Whether the compiler accepts gawk-style nested array syntax such as `a[i][j]` |
 | `putVariable(String, Object)` | Empty map | Pre-set variables available before `BEGIN` |
 
 Output destination is specified per-call on the builder (`execute()`, `execute(PrintStream)`, `execute(OutputStream)`, `execute(Appendable)`, or `execute(AwkSink)`). See the [Custom Output](java-output.html) guide for details.
 
 For more on passing variables to scripts, see [Variables and Arguments](java-variables.html).
+
+By default, Jawk accepts both classic multi-dimensional array syntax (`a[i, j]`) and gawk-style arrays of arrays (`a[i][j]`). Disable the gawk-style parser mode when you need strict classic AWK parsing:
+
+```java
+AwkSettings settings = new AwkSettings();
+settings.setAllowArraysOfArrays(false);
+
+Awk awk = new Awk(settings);
+```
 
 Construct it with extension instances when you want those functions available to the script:
 

--- a/src/test/java/io/jawk/AwkParserTest.java
+++ b/src/test/java/io/jawk/AwkParserTest.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.junit.Test;
 import io.jawk.frontend.ast.LexerException;
+import io.jawk.frontend.ast.ParserException;
+import io.jawk.util.AwkSettings;
 
 public class AwkParserTest {
 
@@ -189,6 +191,15 @@ public class AwkParserTest {
 				.script("BEGIN { n = 2; n **= 2; print n }")
 				.expectLines("4")
 				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysCanBeDisabled() {
+		AwkSettings settings = new AwkSettings();
+		settings.setAllowArraysOfArrays(false);
+		Awk awk = new Awk(settings);
+
+		assertThrows(ParserException.class, () -> awk.compile("BEGIN { a[1][2] = 42 }"));
 	}
 
 	@Test

--- a/src/test/java/io/jawk/AwkParserTest.java
+++ b/src/test/java/io/jawk/AwkParserTest.java
@@ -200,6 +200,7 @@ public class AwkParserTest {
 		Awk awk = new Awk(settings);
 
 		assertThrows(ParserException.class, () -> awk.compile("BEGIN { a[1][2] = 42 }"));
+		assertThrows(RuntimeException.class, () -> awk.compile("BEGIN { print ((\"x\" in a[1]) ? 1 : 0) }"));
 	}
 
 	@Test

--- a/src/test/java/io/jawk/AwkParserTest.java
+++ b/src/test/java/io/jawk/AwkParserTest.java
@@ -201,6 +201,7 @@ public class AwkParserTest {
 
 		assertThrows(ParserException.class, () -> awk.compile("BEGIN { a[1][2] = 42 }"));
 		assertThrows(RuntimeException.class, () -> awk.compile("BEGIN { print ((\"x\" in a[1]) ? 1 : 0) }"));
+		assertThrows(RuntimeException.class, () -> awk.compile("BEGIN { for (k in a[1]) print k }"));
 	}
 
 	@Test

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -824,28 +824,28 @@ public class AwkTest {
 
 	@Test
 	public void testArraysOfArraysReportLineNumberWhenScalarUsedAsArray() throws Exception {
-		AwkTestSupport.TestResult result = AwkTestSupport
-				.awkTest("arrays of arrays scalar used as array line number")
-				.script("BEGIN {\n  a[1] = 5\n  print a[1][2]\n}")
-				.expectThrow(AwkRuntimeException.class)
-				.run();
-		result.assertExpected();
-		AwkRuntimeException ex = (AwkRuntimeException) result.thrownException();
-		assertEquals(3, ex.getLineNumber());
-		assertTrue(ex.getMessage(), ex.getMessage().contains("Attempting to use a scalar as an array."));
+		assertRuntimeExceptionLineNumber(
+				"arrays of arrays scalar used as array line number",
+				3,
+				"Attempting to use a scalar as an array.",
+				"BEGIN {", // 1
+				"  a[1] = 5", // 2
+				"  print a[1][2]", // 3
+				"}"); // 4
 	}
 
 	@Test
 	public void testArraysOfArraysReportLineNumberWhenArrayUsedAsScalarSubscript() throws Exception {
-		AwkTestSupport.TestResult result = AwkTestSupport
-				.awkTest("arrays of arrays array used as scalar subscript line number")
-				.script("BEGIN {\n  a[1][1] = 1\n  b[1][1] = 2\n  print b[a[1]]\n}")
-				.expectThrow(AwkRuntimeException.class)
-				.run();
-		result.assertExpected();
-		AwkRuntimeException ex = (AwkRuntimeException) result.thrownException();
-		assertEquals(5, ex.getLineNumber());
-		assertTrue(ex.getMessage(), ex.getMessage().contains("Attempting to use an array in a scalar context."));
+		assertRuntimeExceptionLineNumber(
+				"arrays of arrays array used as scalar subscript line number",
+				5,
+				"Attempting to use an array in a scalar context.",
+				"BEGIN {", // 1
+				"  a[1][1] = 1", // 2
+				"", // 3
+				"  b[1][1] = 2", // 4
+				"  print b[a[1]]", // 5
+				"}"); // 6
 	}
 
 	@Test
@@ -957,6 +957,23 @@ public class AwkTest {
 				.stdin("a\nb\nc\n")
 				.expect("a\nb\n")
 				.runAndAssert();
+	}
+
+	private void assertRuntimeExceptionLineNumber(
+			String description,
+			int expectedLineNumber,
+			String expectedMessage,
+			String... scriptLines)
+			throws Exception {
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.awkTest(description)
+				.script(String.join("\n", scriptLines))
+				.expectThrow(AwkRuntimeException.class)
+				.run();
+		result.assertExpected();
+		AwkRuntimeException ex = (AwkRuntimeException) result.thrownException();
+		assertEquals(expectedLineNumber, ex.getLineNumber());
+		assertTrue(ex.getMessage(), ex.getMessage().contains(expectedMessage));
 	}
 
 	@Test

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -822,6 +822,16 @@ public class AwkTest {
 	}
 
 	@Test
+	public void testArraysOfArraysReadAutovivifiesMissingParentSubarray() throws Exception {
+		AwkTestSupport
+				.awkTest("arrays of arrays read autovivifies missing parent subarray")
+				.script(
+						"BEGIN { print \"[\" a[1][2] \"]\"; print (((1 in a) ? \"yes\" : \"no\") \" \" ((2 in a[1]) ? \"yes\" : \"no\")) }")
+				.expectLines("[]", "yes yes")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testArraysOfArraysMembershipDeleteAndIteration() throws Exception {
 		AwkSettings settings = new AwkSettings();
 		settings.setUseSortedArrayKeys(true);

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import org.junit.Test;
 import io.jawk.backend.AVM;
 import io.jawk.frontend.ast.ParserException;
+import io.jawk.jrt.AwkRuntimeException;
 import io.jawk.jrt.AppendableAwkSink;
 import io.jawk.jrt.AwkSink;
 import io.jawk.jrt.InputSource;
@@ -822,6 +823,32 @@ public class AwkTest {
 	}
 
 	@Test
+	public void testArraysOfArraysReportLineNumberWhenScalarUsedAsArray() throws Exception {
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.awkTest("arrays of arrays scalar used as array line number")
+				.script("BEGIN {\n  a[1] = 5\n  print a[1][2]\n}")
+				.expectThrow(AwkRuntimeException.class)
+				.run();
+		result.assertExpected();
+		AwkRuntimeException ex = (AwkRuntimeException) result.thrownException();
+		assertEquals(3, ex.getLineNumber());
+		assertTrue(ex.getMessage(), ex.getMessage().contains("Attempting to use a scalar as an array."));
+	}
+
+	@Test
+	public void testArraysOfArraysReportLineNumberWhenArrayUsedAsScalarSubscript() throws Exception {
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.awkTest("arrays of arrays array used as scalar subscript line number")
+				.script("BEGIN {\n  a[1][1] = 1\n  b[1][1] = 2\n  print b[a[1]]\n}")
+				.expectThrow(AwkRuntimeException.class)
+				.run();
+		result.assertExpected();
+		AwkRuntimeException ex = (AwkRuntimeException) result.thrownException();
+		assertEquals(5, ex.getLineNumber());
+		assertTrue(ex.getMessage(), ex.getMessage().contains("Attempting to use an array in a scalar context."));
+	}
+
+	@Test
 	public void testArraysOfArraysReadAutovivifiesMissingParentSubarray() throws Exception {
 		AwkTestSupport
 				.awkTest("arrays of arrays read autovivifies missing parent subarray")
@@ -850,7 +877,7 @@ public class AwkTest {
 		AwkTestSupport
 				.awkTest("arrays of arrays nested increment")
 				.script("BEGIN { old = a[1][2]++; print old, a[1][2]; ++a[1][2]; print a[1][2] }")
-				.expectLines(" 1", "2")
+				.expectLines("0 1", "2")
 				.runAndAssert();
 	}
 

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -795,6 +795,123 @@ public class AwkTest {
 	}
 
 	@Test
+	public void testArraysOfArraysAssignmentAndLookup() throws Exception {
+		AwkTestSupport
+				.awkTest("arrays of arrays assignment and lookup")
+				.script("BEGIN { a[1][2] = 42; print a[1][2] }")
+				.expect("42\n")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysSupportsMixedCommaSubscripts() throws Exception {
+		AwkTestSupport
+				.awkTest("arrays of arrays mixed with comma subscripts")
+				.script("BEGIN { SUBSEP = \"@\"; a[1][2,3] = 42; print a[1][2 SUBSEP 3]; print a[1][2,3] }")
+				.expect("42\n42\n")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysRejectScalarAsArray() throws Exception {
+		AwkTestSupport
+				.awkTest("arrays of arrays reject scalar as array")
+				.script("BEGIN { a[1] = 5; print a[1][2] }")
+				.expectThrow(RuntimeException.class)
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysMembershipDeleteAndIteration() throws Exception {
+		AwkSettings settings = new AwkSettings();
+		settings.setUseSortedArrayKeys(true);
+
+		AwkTestSupport
+				.awkTest("arrays of arrays membership delete and iteration")
+				.withAwk(new Awk(settings))
+				.script(
+						"BEGIN { a[1][\"x\"] = 1; a[1][\"y\"] = 2; print ((\"x\" in a[1]) ? \"yes\" : \"no\"); delete a[1][\"x\"]; print ((\"x\" in a[1]) ? \"yes\" : \"no\"); for (k in a[1]) print k \":\" a[1][k] }")
+				.expectLines("yes", "no", "y:2")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysSupportsNestedIncrement() throws Exception {
+		AwkTestSupport
+				.awkTest("arrays of arrays nested increment")
+				.script("BEGIN { old = a[1][2]++; print old, a[1][2]; ++a[1][2]; print a[1][2] }")
+				.expectLines(" 1", "2")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysSupportsSplitIntoSubarray() throws Exception {
+		AwkTestSupport
+				.awkTest("split into subarray")
+				.script("BEGIN { print split(\"x y\", a[1]), a[1][1], a[1][2] }")
+				.expectLines("2 x y")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysSupportsGetlineIntoSubarray() throws Exception {
+		AwkTestSupport
+				.awkTest("getline into subarray")
+				.script("BEGIN { getline a[1][2]; print a[1][2] }")
+				.stdin("hello\n")
+				.expect("hello\n")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysSupportsSubOnNestedElement() throws Exception {
+		AwkTestSupport
+				.awkTest("sub on nested array element")
+				.script("BEGIN { a[1][2] = \"abc\"; print sub(/b/, \"x\", a[1][2]), a[1][2] }")
+				.expectLines("1 axc")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysSupportsFunctionArrayParameters() throws Exception {
+		AwkTestSupport
+				.awkTest("subarray passed as array parameter")
+				.script("function fill(arr) { arr[\"key\"] = \"value\" } BEGIN { fill(a[1]); print a[1][\"key\"] }")
+				.expectLines("value")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysSupportsDeletingPassedSubarrays() throws Exception {
+		AwkTestSupport
+				.awkTest("delete passed subarray")
+				.script(
+						"function f(c, b) { delete b; b[1] = 1; print c[1][1], b[1]; delete c[2] } BEGIN { a[1][1] = 11; a[1][2] = 12; a[2] = 2; delete a[1][1]; f(a, a[1]); print a[1][1]; print length(a), length(a[1]); delete a; print length(a), length(a[1]), length(a); a[1][1] = 11 }")
+				.expectLines("1 1", "1", "1 1", "0 0 1")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysRejectArrayAsScalarSubscript() throws Exception {
+		AwkTestSupport
+				.awkTest("array value cannot be used as scalar subscript")
+				.script(
+						"function f(arr, s) { delete arr[s[1]][1] } BEGIN { a[1][1] = 1; b[1][1] = 11; f(b, a) }")
+				.expectThrow(RuntimeException.class)
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysHandlesNestedLengthIterationAndMutation() throws Exception {
+		AwkTestSupport
+				.awkTest("gawk-style arrays of arrays flow")
+				.script(
+						"function f(x, i) { for (i = 1; i <= length(x); i++) print x[i]; x[1] = 1001 } BEGIN { a[1][1] = 10; a[1][2] = 20; a[1][3] = 30; a[2] = \"hello world! we have multi-dimensional array\"; a[3, \"X\"] = \"Y\"; print length(a), length(a[1]); delete a[2]; delete a[3, \"X\"]; a[2][1] = 100; a[2][2] = 200; a[2][3] = 300; for (i in a) { sum[i] = 0; for (j in a[i]) sum[i] += a[i][j] } print sum[1], sum[2]; f(a[1]); print a[1][1] }")
+				.expectLines("3 3", "60 600", "10", "20", "30", "1001")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testGetlineDefaultVariable() throws Exception {
 		String script = "BEGIN { while (getline && n++ < 2) print; exit }";
 		AwkTestSupport

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -873,11 +873,39 @@ public class AwkTest {
 	}
 
 	@Test
+	public void testArraysOfArraysInDoesNotAutovivifyMissingSubarray() throws Exception {
+		AwkTestSupport
+				.awkTest("arrays of arrays in does not autovivify missing subarray")
+				.script("BEGIN { print ((\"x\" in a[1]) ? \"yes\" : \"no\"); print ((1 in a) ? \"yes\" : \"no\") }")
+				.expectLines("no", "no")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysForInDoesNotAutovivifyMissingSubarray() throws Exception {
+		AwkTestSupport
+				.awkTest("arrays of arrays for-in does not autovivify missing subarray")
+				.script("BEGIN { for (k in a[1]) print k; print ((1 in a) ? \"yes\" : \"no\") }")
+				.expectLines("no")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testArraysOfArraysSupportsNestedIncrement() throws Exception {
 		AwkTestSupport
 				.awkTest("arrays of arrays nested increment")
 				.script("BEGIN { old = a[1][2]++; print old, a[1][2]; ++a[1][2]; print a[1][2] }")
 				.expectLines("0 1", "2")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testArraysOfArraysPostfixOperatorsUseNumericOldValue() throws Exception {
+		AwkTestSupport
+				.awkTest("arrays of arrays postfix operators use numeric old value")
+				.script(
+						"BEGIN { a[1][1] = \"abc\"; oldInc = a[1][1]++; a[1][2] = \"abc\"; oldDec = a[1][2]--; print oldInc, a[1][1]; print oldDec, a[1][2] }")
+				.expectLines("0 1", "0 -1")
 				.runAndAssert();
 	}
 

--- a/src/test/java/io/jawk/PosixConformanceTest.java
+++ b/src/test/java/io/jawk/PosixConformanceTest.java
@@ -556,7 +556,6 @@ public class PosixConformanceTest {
 
 	@Test
 	public void posix85ForInDeleteAll() throws Exception {
-		Assume.assumeTrue("length(array) is not supported", false);
 		AwkTestSupport
 				.awkTest("POSIX 8.5 for in delete all elements")
 				.script("BEGIN{ split(\"a b c\", a, \" \" ); for (i in a) delete a[i]; print length(a) }")
@@ -744,7 +743,6 @@ public class PosixConformanceTest {
 
 	@Test
 	public void posix104LengthOfArray() throws Exception {
-		Assume.assumeTrue("length(array) is not supported", false);
 		AwkTestSupport
 				.awkTest("POSIX 10.4 length of array")
 				.script("BEGIN{ split(\"a b c\", A, \" \" ); print length(A) }")
@@ -881,7 +879,6 @@ public class PosixConformanceTest {
 
 	@Test
 	public void posix113DeleteArrayClearsAll() throws Exception {
-		Assume.assumeTrue("length(array) is not supported", false);
 		AwkTestSupport
 				.awkTest("POSIX 11.3 delete array clears elements")
 				.script("BEGIN{ split(\"a b\", A, \" \" ); delete A; print length(A) }")


### PR DESCRIPTION
Closes #438

## Summary

This PR adds support for optional gawk-style arrays of arrays (`a[i][j]`) as described in issue #438.

## Changes

### `AwkSettings`
- Added `allowArraysOfArrays` field (default: `true`) to enable/disable chained-bracket syntax at compile time.

### `Awk`
- Thread `allowArraysOfArrays` setting into `AwkParser` via `compile()` and `compileExpression()`.

### `AwkParser`
- When `allowArraysOfArrays` is enabled, parse chained-bracket expressions (`a[i][j]`, `a[i][j][k]`, mixed forms like `a[i][j,k]`) instead of throwing an error.
- Comma subscripts inside a single bracket pair still use `SUBSEP` (unchanged behavior).
- When disabled, the existing parser error is preserved.

### `Opcode` / `AwkTuples`
- Introduced new opcodes for nested array lvalue operations to support reads, writes, `in`, `for-in`, `delete`, `++/--`, and compound assignment on nested arrays.

### `AVM`
- Extended the runtime to execute nested-array tuples, building on the existing generic `Map`-based infrastructure.

## Behavior

| Expression | Behavior |
|---|---|
| `a[1][2] = 42; print a[1][2]` | Prints `42` |
| `a[1][2,3] = 42; print a[1][2,3]` | Inner comma uses `SUBSEP` |
| `a[1,2] = 42; print a[1,2]` | Unchanged |
| `2 in a[1]` | Membership test on subarray |
| `for (k in a[1])` | Iterates subarray |
| `delete a[1][2]` | Removes nested element |
| `allowArraysOfArrays = false` + `a[1][2]` | Parser error |

## Tests

- Added regression tests in `AwkTest` covering the acceptance criteria from the issue.
- Added parser-rejection tests in `AwkParserTest` for when the flag is disabled.

## Documentation

- Updated `README.md`, `compatibility.md`, `java.md`, and `java-compile.md`.