### PR TITLE
[codex] add --posix CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 Jawk is a pure Java implementation of [AWK](https://en.wikipedia.org/wiki/AWK). You can run it as a CLI, embed it directly in Java applications, compile scripts to reusable tuples, evaluate AWK expressions, feed it structured input, load extensions explicitly, and enable a sandboxed runtime when you need tighter execution constraints.
 
-For POSIX-oriented CLI compilation, use `--posix`. It disables gawk-style nested arrays during source compilation, and it is intentionally rejected together with `-L` because precompiled tuples are already compiled before loading.
-
 ## CLI Example
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Jawk is a pure Java implementation of [AWK](https://en.wikipedia.org/wiki/AWK). You can run it as a CLI, embed it directly in Java applications, compile scripts to reusable tuples, evaluate AWK expressions, feed it structured input, load extensions explicitly, and enable a sandboxed runtime when you need tighter execution constraints.
 
+For POSIX-oriented CLI compilation, use `--posix`. It disables gawk-style nested arrays during source compilation, and it is intentionally rejected together with `-L` because precompiled tuples are already compiled before loading.
+
 ## CLI Example
 
 ```shell

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -54,6 +54,7 @@ import io.jawk.util.ScriptSource;
 public final class Cli {
 
 	private static final String JAR_NAME;
+	private static final String POSIX_LOAD_CONFLICT_MESSAGE = "--posix cannot be combined with -L because -L loads a precompiled program.";
 
 	static {
 		String myName;
@@ -191,11 +192,10 @@ public final class Cli {
 				scriptSources.add(new ScriptFileSource(args[++argIdx]));
 			} else if (arg.equals("-L")) {
 				// -L filename : load precompiled program
-				if (posixRequested) {
-					throw new IllegalArgumentException(
-							"--posix cannot be combined with -L because -L loads a precompiled program.");
-				}
 				checkParameterHasArgument(args, argIdx);
+				if (posixRequested) {
+					throw new IllegalArgumentException(POSIX_LOAD_CONFLICT_MESSAGE);
+				}
 				String file = args[++argIdx];
 				try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
 					precompiledProgram = (AwkProgram) ois.readObject();
@@ -233,8 +233,7 @@ public final class Cli {
 			} else if (arg.equals("--posix")) {
 				// --posix : enforce POSIX-compatible compile-time behavior
 				if (precompiledProgram != null) {
-					throw new IllegalArgumentException(
-							"--posix cannot be combined with -L because -L loads a precompiled program.");
+					throw new IllegalArgumentException(POSIX_LOAD_CONFLICT_MESSAGE);
 				}
 				posixRequested = true;
 				settings.setAllowArraysOfArrays(false);

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -225,6 +225,9 @@ public final class Cli {
 			} else if (arg.equals("-S") || arg.equals("--sandbox")) {
 // -S/--sandbox : enable sandbox mode
 				sandbox = true;
+			} else if (arg.equals("--posix")) {
+				// --posix : enforce POSIX-compatible compile-time behavior
+				settings.setAllowArraysOfArrays(false);
 			} else if (arg.equals("--dump-syntax")) {
 // --dump-syntax : dump syntax tree to file
 				dumpSyntaxTree = true;
@@ -409,6 +412,7 @@ public final class Cli {
 								" [-K program-filename]" +
 								" [-o output-filename]" +
 								" [-S|--sandbox]" +
+								" [--posix]" +
 								" [--dump-syntax]" +
 								" [--dump-intermediate]" +
 								" [-s|--no-optimize]" +
@@ -436,6 +440,7 @@ public final class Cli {
 				.println(
 						" -S, --sandbox = (extension) Enable sandbox mode (no system(), redirection, pipelines, or"
 								+ " dynamic extensions).");
+		dest.println(" --posix = Enforce POSIX-compatible behavior such as disabling nested arrays.");
 		dest.println(" --dump-syntax = Print the syntax tree.");
 		dest.println(" --dump-intermediate = Print the intermediate code.");
 		dest.println(" -s, --no-optimize = (extension) Disable optimizations during compilation.");

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -168,6 +168,7 @@ public final class Cli {
 
 		// Parse the arguments
 		int argIdx = 0;
+		boolean posixRequested = false;
 		while (argIdx < args.length) {
 			String arg = args[argIdx];
 			if (arg.length() == 0) {
@@ -190,6 +191,10 @@ public final class Cli {
 				scriptSources.add(new ScriptFileSource(args[++argIdx]));
 			} else if (arg.equals("-L")) {
 				// -L filename : load precompiled program
+				if (posixRequested) {
+					throw new IllegalArgumentException(
+							"--posix cannot be combined with -L because -L loads a precompiled program.");
+				}
 				checkParameterHasArgument(args, argIdx);
 				String file = args[++argIdx];
 				try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
@@ -227,6 +232,11 @@ public final class Cli {
 				sandbox = true;
 			} else if (arg.equals("--posix")) {
 				// --posix : enforce POSIX-compatible compile-time behavior
+				if (precompiledProgram != null) {
+					throw new IllegalArgumentException(
+							"--posix cannot be combined with -L because -L loads a precompiled program.");
+				}
+				posixRequested = true;
 				settings.setAllowArraysOfArrays(false);
 			} else if (arg.equals("--dump-syntax")) {
 // --dump-syntax : dump syntax tree to file
@@ -410,7 +420,6 @@ public final class Cli {
 								" [-f script-filename]" +
 								" [-L program-filename]" +
 								" [-K program-filename]" +
-								" [-o output-filename]" +
 								" [-S|--sandbox]" +
 								" [--posix]" +
 								" [--dump-syntax]" +
@@ -435,7 +444,6 @@ public final class Cli {
 		dest.println();
 		dest.println(" -t = (extension) Maintain array keys in sorted order.");
 		dest.println(" -K filename = Compile to program file and halt.");
-		dest.println(" -o = (extension) Specify output file.");
 		dest
 				.println(
 						" -S, --sandbox = (extension) Enable sandbox mode (no system(), redirection, pipelines, or"

--- a/src/site/markdown/cli-reference.md
+++ b/src/site/markdown/cli-reference.md
@@ -49,7 +49,6 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 >   - `--locale <locale>` sets the locale through `Locale.forLanguageTag(...)`.
 >   - `-t` keeps associative array keys sorted.
 >   - `--posix` enforces POSIX-oriented compile-time behavior such as disabling gawk-style nested arrays.
->   - `--posix` cannot be combined with `-L` because `-L` executes an already compiled tuples file.
 >
 > - Extensions and sandbox
 >

--- a/src/site/markdown/cli-reference.md
+++ b/src/site/markdown/cli-reference.md
@@ -49,6 +49,7 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 >   - `--locale <locale>` sets the locale through `Locale.forLanguageTag(...)`.
 >   - `-t` keeps associative array keys sorted.
 >   - `--posix` enforces POSIX-oriented compile-time behavior such as disabling gawk-style nested arrays.
+>   - `--posix` cannot be combined with `-L` because `-L` executes an already compiled tuples file.
 >
 > - Extensions and sandbox
 >
@@ -73,6 +74,7 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 - `--dump-syntax`, `--dump-intermediate`, `-K`, `-h`, `-?`, and `--list-ext` are non-executing modes.
 - `-S` affects compilation and execution, not just runtime behavior.
 - `--posix` currently disables arrays-of-arrays syntax and related subarray-only operands in order to keep CLI compilation aligned with classic POSIX-style AWK expectations.
+- `--posix` is rejected together with `-L`, because loading precompiled tuples bypasses source compilation entirely.
 - `-L` lets you skip source compilation, but the loaded tuples must still be compatible with the current runtime.
 - `-f` and `-L` are distinct paths: source files compile now, tuple files load now.
 

--- a/src/site/markdown/cli-reference.md
+++ b/src/site/markdown/cli-reference.md
@@ -48,6 +48,7 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 >   - `-r` disables Jawk's default trapping of `IllegalFormatException` for `printf` and `sprintf`.
 >   - `--locale <locale>` sets the locale through `Locale.forLanguageTag(...)`.
 >   - `-t` keeps associative array keys sorted.
+>   - `--posix` enforces POSIX-oriented compile-time behavior such as disabling gawk-style nested arrays.
 >
 > - Extensions and sandbox
 >
@@ -71,6 +72,7 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 
 - `--dump-syntax`, `--dump-intermediate`, `-K`, `-h`, `-?`, and `--list-ext` are non-executing modes.
 - `-S` affects compilation and execution, not just runtime behavior.
+- `--posix` currently disables arrays-of-arrays syntax and related subarray-only operands in order to keep CLI compilation aligned with classic POSIX-style AWK expectations.
 - `-L` lets you skip source compilation, but the loaded tuples must still be compatible with the current runtime.
 - `-f` and `-L` are distinct paths: source files compile now, tuple files load now.
 

--- a/src/site/markdown/cli.md
+++ b/src/site/markdown/cli.md
@@ -96,6 +96,13 @@ Set the field separator with `-F` when you want Jawk to split text records diffe
 $ java -jar jawk-${project.version}-standalone.jar -F : '{ print $1 "," $6 }' /etc/passwd
 ```
 
+Use `--posix` when you want POSIX-oriented compile-time behavior from the CLI. In particular, it disables gawk-style nested arrays, so classic multi-dimensional subscripts such as `a[i, j]` remain valid while `a[i][j]` is rejected:
+
+```shell-session
+$ java -jar jawk-${project.version}-standalone.jar --posix 'BEGIN { a[1,2] = 42; print a[1,2] }'
+42
+```
+
 ## Load Extensions
 
 List the currently registered extension identifiers:

--- a/src/site/markdown/cli.md
+++ b/src/site/markdown/cli.md
@@ -103,6 +103,8 @@ $ java -jar jawk-${project.version}-standalone.jar --posix 'BEGIN { a[1,2] = 42;
 42
 ```
 
+Because `-L` loads an already compiled tuples file, Jawk rejects `--posix` together with `-L` instead of pretending that it can re-apply compile-time restrictions after the fact.
+
 ## Load Extensions
 
 List the currently registered extension identifiers:

--- a/src/site/markdown/compatibility.md
+++ b/src/site/markdown/compatibility.md
@@ -15,7 +15,7 @@ Jawk keeps the AWK language model while adding JVM-oriented capabilities:
 - it exposes a serializable tuple representation for compilation and reuse
 - it can maintain associative array keys in sorted order
 - it supports gawk-style arrays of arrays (`a[i][j]`) in addition to classic AWK multi-dimensional subscripts (`a[i, j]`)
-  This compile-time feature can be disabled, in which case Jawk also rejects subarray operands in array-only positions such as `split(..., a[i])` or `for (k in a[i])`.
+  This compile-time feature can be disabled, in which case Jawk also rejects subarray operands in array-only positions such as `split(..., a[i])` or `for (k in a[i])`. From the CLI, use `--posix` to disable it.
 - it supports explicit extensions
 - it offers a sandboxed compiler and runtime
 

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -84,6 +84,37 @@ public class CliOptionTest {
 	}
 
 	@Test
+	public void posixOptionRejectsPrecompiledProgramsInEitherOrder() throws Exception {
+		File compiled = tempFolder.newFile("program.ser");
+		writeProgram(compiled, "BEGIN { print 1 }");
+
+		AwkTestSupport.TestResult posixThenLoad = AwkTestSupport
+				.cliTest("CLI rejects --posix before -L")
+				.argument("--posix", "-L", compiled.getAbsolutePath())
+				.expectThrow(IllegalArgumentException.class)
+				.run();
+		assertTrue(posixThenLoad.thrownException().getMessage().contains("--posix cannot be combined with -L"));
+
+		AwkTestSupport.TestResult loadThenPosix = AwkTestSupport
+				.cliTest("CLI rejects --posix after -L")
+				.argument("-L", compiled.getAbsolutePath(), "--posix")
+				.expectThrow(IllegalArgumentException.class)
+				.run();
+		assertTrue(loadThenPosix.thrownException().getMessage().contains("--posix cannot be combined with -L"));
+	}
+
+	@Test
+	public void helpOutputDoesNotAdvertiseUnsupportedOutputOption() throws Exception {
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.cliTest("CLI help omits unsupported -o option")
+				.argument("-h")
+				.run();
+
+		assertFalse(result.output().contains("[-o output-filename]"));
+		assertFalse(result.output().contains(" -o = "));
+	}
+
+	@Test
 	public void loadOptionWithWrongSerializedTypeThrowsFriendlyError() throws Exception {
 		File bad = tempFolder.newFile("wrong-type.ser");
 		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(bad))) {
@@ -97,5 +128,11 @@ public class CliOptionTest {
 				{ "-L", bad.getAbsolutePath(), "{ print }" }));
 		assertTrue(ex.getMessage().contains("does not contain a valid precompiled AwkProgram"));
 		assertTrue(ex.getCause() instanceof ClassCastException);
+	}
+
+	private static void writeProgram(File target, String script) throws Exception {
+		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(target))) {
+			oos.writeObject(new Awk().compile(script));
+		}
 	}
 }

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -23,6 +23,7 @@ package io.jawk;
  */
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -31,6 +32,7 @@ import java.io.ObjectOutputStream;
 import org.junit.Test;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+import io.jawk.frontend.ast.ParserException;
 
 public class CliOptionTest {
 
@@ -51,6 +53,34 @@ public class CliOptionTest {
 		cli.parse(new String[] { "--no-optimize", "{ print 1 }" });
 
 		assertTrue(cli.isDisableOptimize());
+	}
+
+	@Test
+	public void posixOptionDisablesArraysOfArrays() {
+		Cli cli = new Cli();
+		cli.parse(new String[] { "--posix", "{ print 1 }" });
+
+		assertFalse(cli.getSettings().isAllowArraysOfArrays());
+	}
+
+	@Test
+	public void posixOptionRejectsNestedArrays() throws Exception {
+		AwkTestSupport
+				.cliTest("CLI --posix rejects nested arrays")
+				.argument("--posix")
+				.script("BEGIN { a[1][2] = 42 }")
+				.expectThrow(ParserException.class)
+				.runAndAssert();
+	}
+
+	@Test
+	public void posixOptionStillAllowsClassicMultidimensionalSubscripts() throws Exception {
+		AwkTestSupport
+				.cliTest("CLI --posix still allows classic multidimensional subscripts")
+				.argument("--posix")
+				.script("BEGIN { a[1,2] = 42; print a[1,2] }")
+				.expectLines("42")
+				.runAndAssert();
 	}
 
 	@Test

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -93,6 +93,7 @@ public class CliOptionTest {
 				.argument("--posix", "-L", compiled.getAbsolutePath())
 				.expectThrow(IllegalArgumentException.class)
 				.run();
+		posixThenLoad.assertExpected();
 		assertTrue(posixThenLoad.thrownException().getMessage().contains("--posix cannot be combined with -L"));
 
 		AwkTestSupport.TestResult loadThenPosix = AwkTestSupport
@@ -100,7 +101,20 @@ public class CliOptionTest {
 				.argument("-L", compiled.getAbsolutePath(), "--posix")
 				.expectThrow(IllegalArgumentException.class)
 				.run();
+		loadThenPosix.assertExpected();
 		assertTrue(loadThenPosix.thrownException().getMessage().contains("--posix cannot be combined with -L"));
+	}
+
+	@Test
+	public void posixLoadOptionWithoutFilenameReportsMissingArgument() throws Exception {
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.cliTest("CLI reports missing -L argument before --posix incompatibility")
+				.argument("--posix", "-L")
+				.expectThrow(IllegalArgumentException.class)
+				.run();
+
+		result.assertExpected();
+		assertTrue(result.thrownException().getMessage().contains("Need additional argument for -L"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

This change adds a `--posix` CLI option that enforces POSIX-oriented compile-time behavior for Jawk by disabling gawk-style nested arrays.

It also:
- updates CLI help and site documentation to describe the new flag
- adds CLI regression coverage for `--posix`
- verifies that classic multi-dimensional subscripts such as `a[i, j]` still work while `a[i][j]` is rejected

## Why

Nested arrays are now supported by Jawk, but the CLI still needs an explicit way to opt back into POSIX-style behavior.

## Validation

- `mvn formatter:format`
- `mvn test -Dtest=CliOptionTest`
- `mvn verify` was also run; it still reports existing unrelated compatibility-suite failures outside this change set