### PR TITLE
[codex] Group compatibility suites by upstream package

### DIFF
--- a/src/it/java/io/jawk/CompatibilityTestResources.java
+++ b/src/it/java/io/jawk/CompatibilityTestResources.java
@@ -30,11 +30,18 @@ import java.nio.file.Paths;
  * Resolves vendored integration-test resources directly from the repository
  * checkout instead of relying on the Maven test classpath layout.
  */
-final class CompatibilityTestResources {
+public final class CompatibilityTestResources {
 
 	private CompatibilityTestResources() {}
 
-	static Path projectDirectory(Class<?> anchor) {
+	/**
+	 * Resolves the Maven project directory from the compiled location of an
+	 * integration-test class.
+	 *
+	 * @param anchor a class loaded from the current test output
+	 * @return the project base directory
+	 */
+	public static Path projectDirectory(Class<?> anchor) {
 		try {
 			Path testClassesDirectory = Paths
 					.get(anchor.getProtectionDomain().getCodeSource().getLocation().toURI())
@@ -54,7 +61,17 @@ final class CompatibilityTestResources {
 		}
 	}
 
-	static Path resourceDirectory(Class<?> anchor, String firstSegment, String... additionalSegments) {
+	/**
+	 * Resolves a vendored integration-test resource directory relative to
+	 * {@code src/it/resources}.
+	 *
+	 * @param anchor a class loaded from the current test output
+	 * @param firstSegment the first resource path segment under
+	 *        {@code src/it/resources}
+	 * @param additionalSegments any remaining resource path segments
+	 * @return the resolved resource directory path
+	 */
+	public static Path resourceDirectory(Class<?> anchor, String firstSegment, String... additionalSegments) {
 		Path resourceDirectory = projectDirectory(anchor).resolve(Paths.get("src", "it", "resources", firstSegment));
 		for (String segment : additionalSegments) {
 			resourceDirectory = resourceDirectory.resolve(segment);

--- a/src/it/java/io/jawk/gawk/AbstractGawkSuite.java
+++ b/src/it/java/io/jawk/gawk/AbstractGawkSuite.java
@@ -1,10 +1,10 @@
-package io.jawk;
+package io.jawk.gawk;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * Jawk
  * ჻჻჻჻჻჻
- * Copyright 2006 - 2026 MetricsHub
+ * Copyright (C) 2006 - 2026 MetricsHub
  * ჻჻჻჻჻჻
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -28,9 +28,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import io.jawk.CompatibilityTestResources;
 
 /**
- * Shared helpers for the explicit gawk compatibility integration suites.
+ * Shared helpers for the explicit gawk compatibility integration suites
+ * transcribed from the vendored GNU Awk test suite.
  */
 abstract class AbstractGawkSuite {
 

--- a/src/it/java/io/jawk/gawk/GawkExtensionIT.java
+++ b/src/it/java/io/jawk/gawk/GawkExtensionIT.java
@@ -1,4 +1,4 @@
-package io.jawk;
+package io.jawk.gawk;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -22,10 +22,13 @@ package io.jawk;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import io.jawk.AwkTestSupport;
 import org.junit.Test;
 
 /**
- * Extension-oriented gawk compatibility cases mirrored from the vendored extension-style gawk groups.
+ * Extension-oriented gawk compatibility cases mirrored from the vendored
+ * extension-style GNU Awk test groups.
+ * Upstream source: {@code git://git.savannah.gnu.org/gawk.git}
  */
 public class GawkExtensionIT extends AbstractGawkSuite {
 

--- a/src/it/java/io/jawk/gawk/GawkIT.java
+++ b/src/it/java/io/jawk/gawk/GawkIT.java
@@ -1,4 +1,4 @@
-package io.jawk;
+package io.jawk.gawk;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -22,10 +22,13 @@ package io.jawk;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import io.jawk.AwkTestSupport;
 import org.junit.Test;
 
 /**
- * Core gawk compatibility cases mirrored from the basic and Unix test groups in the vendored gawk suite.
+ * Core gawk compatibility cases mirrored from the basic and Unix test groups
+ * in the vendored GNU Awk test suite.
+ * Upstream source: {@code git://git.savannah.gnu.org/gawk.git}
  */
 public class GawkIT extends AbstractGawkSuite {
 

--- a/src/it/java/io/jawk/gawk/GawkLocaleIT.java
+++ b/src/it/java/io/jawk/gawk/GawkLocaleIT.java
@@ -1,4 +1,4 @@
-package io.jawk;
+package io.jawk.gawk;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -22,10 +22,13 @@ package io.jawk;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import io.jawk.AwkTestSupport;
 import org.junit.Test;
 
 /**
- * Locale- and charset-sensitive gawk compatibility cases mirrored from the vendored locale test groups.
+ * Locale- and charset-sensitive gawk compatibility cases mirrored from the
+ * vendored GNU Awk locale test groups.
+ * Upstream source: {@code git://git.savannah.gnu.org/gawk.git}
  */
 public class GawkLocaleIT extends AbstractGawkSuite {
 

--- a/src/it/java/io/jawk/gawk/GawkOptionalFeatureIT.java
+++ b/src/it/java/io/jawk/gawk/GawkOptionalFeatureIT.java
@@ -1,4 +1,4 @@
-package io.jawk;
+package io.jawk.gawk;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -22,10 +22,13 @@ package io.jawk;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import io.jawk.AwkTestSupport;
 import org.junit.Test;
 
 /**
- * Optional-feature and environment-specific gawk compatibility cases mirrored from the vendored optional gawk groups.
+ * Optional-feature and environment-specific gawk compatibility cases mirrored
+ * from the vendored GNU Awk optional test groups.
+ * Upstream source: {@code git://git.savannah.gnu.org/gawk.git}
  */
 public class GawkOptionalFeatureIT extends AbstractGawkSuite {
 

--- a/src/it/java/io/jawk/onetrueawk/BwkMiscIT.java
+++ b/src/it/java/io/jawk/onetrueawk/BwkMiscIT.java
@@ -1,4 +1,4 @@
-package io.jawk;
+package io.jawk.onetrueawk;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import io.jawk.AwkTestSupport;
+import io.jawk.CompatibilityTestResources;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,11 +38,12 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration suite based on BWK miscellaneous compatibility tests. Each AWK
- * script in the BWK compatibility resources executes against its corresponding
- * input file and its output is compared with the recorded result.
+ * Integration suite based on the BWK miscellaneous compatibility tests vendored
+ * from the One True Awk upstream repository. Each AWK script executes against
+ * its corresponding input file and its output is compared with the recorded
+ * result.
  *
- * @see <a href="https://github.com/onetrueawk/awk">One True Awk</a>
+ * @see <a href="https://github.com/onetrueawk/awk">BWK / One True Awk upstream repository</a>
  */
 @RunWith(Parameterized.class)
 public class BwkMiscIT {

--- a/src/it/java/io/jawk/onetrueawk/BwkPIT.java
+++ b/src/it/java/io/jawk/onetrueawk/BwkPIT.java
@@ -1,4 +1,4 @@
-package io.jawk;
+package io.jawk.onetrueawk;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -24,11 +24,11 @@ package io.jawk;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import io.jawk.AwkTestSupport;
+import io.jawk.CompatibilityTestResources;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,20 +38,20 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration suite based on BWK text-processing tests. Each AWK script in the
- * BWK compatibility resources executes against the shared BWK input file and
- * its output is compared with the recorded result.
+ * Integration suite based on the BWK pattern tests vendored from the One True
+ * Awk upstream repository. Each AWK script executes against the shared BWK
+ * input file and its output is compared with the recorded result.
  *
- * @see <a href="https://github.com/onetrueawk/awk">One True Awk</a>
+ * @see <a href="https://github.com/onetrueawk/awk">BWK / One True Awk upstream repository</a>
  */
 @RunWith(Parameterized.class)
-public class BwkTIT {
+public class BwkPIT {
 
-	private static Path bwkTDirectory;
+	private static Path bwkPDirectory;
 	private static Path scriptsDirectory;
 
 	/**
-	 * Initializes the BWK.t integration suite.
+	 * Initializes the BWK.p integration suite.
 	 *
 	 * @throws Exception when resource discovery fails
 	 */
@@ -59,19 +59,19 @@ public class BwkTIT {
 	public static void beforeAll() throws Exception {}
 
 	/**
-	 * Returns the BWK.t script names discovered from the integration-test
+	 * Returns the BWK.p script names discovered from the integration-test
 	 * resources.
 	 *
 	 * @return the parameter values for this suite
 	 * @throws Exception when resource discovery fails
 	 */
-	@Parameters(name = "BWK.t {0}")
+	@Parameters(name = "BWK.p {0}")
 	public static Iterable<String> awkList() throws Exception {
-		bwkTDirectory = CompatibilityTestResources.resourceDirectory(BwkTIT.class, "bwk", "t");
-		if (!bwkTDirectory.toFile().isDirectory()) {
-			throw new IOException(bwkTDirectory + " is not a directory");
+		bwkPDirectory = CompatibilityTestResources.resourceDirectory(BwkPIT.class, "bwk", "p");
+		if (!bwkPDirectory.toFile().isDirectory()) {
+			throw new IOException(bwkPDirectory + " is not a directory");
 		}
-		scriptsDirectory = bwkTDirectory.resolve("scripts");
+		scriptsDirectory = bwkPDirectory.resolve("scripts");
 		if (!scriptsDirectory.toFile().isDirectory()) {
 			throw new IOException("scripts is not a directory");
 		}
@@ -82,7 +82,7 @@ public class BwkTIT {
 
 		return Arrays
 				.stream(scriptFiles)
-				.filter(scriptFile -> scriptFile.getName().startsWith("t."))
+				.filter(scriptFile -> scriptFile.getName().startsWith("p."))
 				.map(File::getName)
 				.sorted()
 				.collect(Collectors.toList());
@@ -93,53 +93,28 @@ public class BwkTIT {
 	public String awkName;
 
 	/**
-	 * Executes one BWK.t script and compares its output with the expected result.
+	 * Executes one BWK.p script and compares its output with the expected result.
 	 *
 	 * @throws Exception when the test setup or execution fails unexpectedly
 	 */
 	@Test
 	public void test() throws Exception {
-		Path awkPath = scriptsDirectory.resolve(awkName);
-		Path okPath = bwkTDirectory.resolve("results/" + awkName + ".ok");
-		Path inputPath = bwkTDirectory.resolve("inputs/test.data");
+		Path awkScriptPath = scriptsDirectory.resolve(awkName);
+		Path okFilePath = bwkPDirectory.resolve("results/" + awkName + ".ok");
+		Path inputFilePath = bwkPDirectory.resolve("inputs/test.countries");
 
-		int expectedCode = 0;
-		if ("t.exit".equals(awkName)) {
-			expectedCode = 1;
-		} else if ("t.exit1".equals(awkName)) {
-			expectedCode = 2;
-		}
-
-		if ("t.in2".equals(awkName) || "t.intest2".equals(awkName)) {
-			String expectedResult = Files
-					.readAllLines(okPath, StandardCharsets.UTF_8)
-					.stream()
-					.sorted()
-					.collect(Collectors.joining("\n"));
-
-			AwkTestSupport
-					.awkTest("BWK.t " + awkName)
-					.script(awkPath)
-					.operand(inputPath.toString())
-					.postProcessWith(output -> Arrays.stream(output.split("\\R")).sorted().collect(Collectors.joining("\n")))
-					.expect(expectedResult)
-					.expectExit(expectedCode)
-					.build()
-					.runAndAssert();
-		} else {
-			AwkTestSupport
-					.awkTest("BWK.t " + awkName)
-					.script(awkPath)
-					.operand(inputPath.toString())
-					.expectLines(okPath)
-					.expectExit(expectedCode)
-					.build()
-					.runAndAssert();
-		}
+		AwkTestSupport
+				.cliTest("BWK.p " + awkName)
+				.argument("-f", awkScriptPath.toString())
+				.operand(inputFilePath.toString())
+				.postProcessWith(output -> output.replace(inputFilePath.toString(), inputFilePath.getFileName().toString()))
+				.expectLines(okFilePath)
+				.build()
+				.runAndAssert();
 	}
 
 	/**
-	 * Finalizes the BWK.t integration suite.
+	 * Finalizes the BWK.p integration suite.
 	 *
 	 * @throws Exception unused hook retained for suite symmetry
 	 */

--- a/src/it/java/io/jawk/onetrueawk/BwkTIT.java
+++ b/src/it/java/io/jawk/onetrueawk/BwkTIT.java
@@ -1,4 +1,4 @@
-package io.jawk;
+package io.jawk.onetrueawk;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -24,9 +24,13 @@ package io.jawk;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import io.jawk.AwkTestSupport;
+import io.jawk.CompatibilityTestResources;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,20 +40,20 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Integration suite based on BWK pattern tests. Each AWK script in the BWK
- * compatibility resources executes against the shared BWK input file and its
- * output is compared with the recorded result.
+ * Integration suite based on the BWK text-processing tests vendored from the
+ * One True Awk upstream repository. Each AWK script executes against the shared
+ * BWK input file and its output is compared with the recorded result.
  *
- * @see <a href="https://github.com/onetrueawk/awk">One True Awk</a>
+ * @see <a href="https://github.com/onetrueawk/awk">BWK / One True Awk upstream repository</a>
  */
 @RunWith(Parameterized.class)
-public class BwkPIT {
+public class BwkTIT {
 
-	private static Path bwkPDirectory;
+	private static Path bwkTDirectory;
 	private static Path scriptsDirectory;
 
 	/**
-	 * Initializes the BWK.p integration suite.
+	 * Initializes the BWK.t integration suite.
 	 *
 	 * @throws Exception when resource discovery fails
 	 */
@@ -57,19 +61,19 @@ public class BwkPIT {
 	public static void beforeAll() throws Exception {}
 
 	/**
-	 * Returns the BWK.p script names discovered from the integration-test
+	 * Returns the BWK.t script names discovered from the integration-test
 	 * resources.
 	 *
 	 * @return the parameter values for this suite
 	 * @throws Exception when resource discovery fails
 	 */
-	@Parameters(name = "BWK.p {0}")
+	@Parameters(name = "BWK.t {0}")
 	public static Iterable<String> awkList() throws Exception {
-		bwkPDirectory = CompatibilityTestResources.resourceDirectory(BwkPIT.class, "bwk", "p");
-		if (!bwkPDirectory.toFile().isDirectory()) {
-			throw new IOException(bwkPDirectory + " is not a directory");
+		bwkTDirectory = CompatibilityTestResources.resourceDirectory(BwkTIT.class, "bwk", "t");
+		if (!bwkTDirectory.toFile().isDirectory()) {
+			throw new IOException(bwkTDirectory + " is not a directory");
 		}
-		scriptsDirectory = bwkPDirectory.resolve("scripts");
+		scriptsDirectory = bwkTDirectory.resolve("scripts");
 		if (!scriptsDirectory.toFile().isDirectory()) {
 			throw new IOException("scripts is not a directory");
 		}
@@ -80,7 +84,7 @@ public class BwkPIT {
 
 		return Arrays
 				.stream(scriptFiles)
-				.filter(scriptFile -> scriptFile.getName().startsWith("p."))
+				.filter(scriptFile -> scriptFile.getName().startsWith("t."))
 				.map(File::getName)
 				.sorted()
 				.collect(Collectors.toList());
@@ -91,28 +95,53 @@ public class BwkPIT {
 	public String awkName;
 
 	/**
-	 * Executes one BWK.p script and compares its output with the expected result.
+	 * Executes one BWK.t script and compares its output with the expected result.
 	 *
 	 * @throws Exception when the test setup or execution fails unexpectedly
 	 */
 	@Test
 	public void test() throws Exception {
-		Path awkScriptPath = scriptsDirectory.resolve(awkName);
-		Path okFilePath = bwkPDirectory.resolve("results/" + awkName + ".ok");
-		Path inputFilePath = bwkPDirectory.resolve("inputs/test.countries");
+		Path awkPath = scriptsDirectory.resolve(awkName);
+		Path okPath = bwkTDirectory.resolve("results/" + awkName + ".ok");
+		Path inputPath = bwkTDirectory.resolve("inputs/test.data");
 
-		AwkTestSupport
-				.cliTest("BWK.p " + awkName)
-				.argument("-f", awkScriptPath.toString())
-				.operand(inputFilePath.toString())
-				.postProcessWith(output -> output.replace(inputFilePath.toString(), inputFilePath.getFileName().toString()))
-				.expectLines(okFilePath)
-				.build()
-				.runAndAssert();
+		int expectedCode = 0;
+		if ("t.exit".equals(awkName)) {
+			expectedCode = 1;
+		} else if ("t.exit1".equals(awkName)) {
+			expectedCode = 2;
+		}
+
+		if ("t.in2".equals(awkName) || "t.intest2".equals(awkName)) {
+			String expectedResult = Files
+					.readAllLines(okPath, StandardCharsets.UTF_8)
+					.stream()
+					.sorted()
+					.collect(Collectors.joining("\n"));
+
+			AwkTestSupport
+					.awkTest("BWK.t " + awkName)
+					.script(awkPath)
+					.operand(inputPath.toString())
+					.postProcessWith(output -> Arrays.stream(output.split("\\R")).sorted().collect(Collectors.joining("\n")))
+					.expect(expectedResult)
+					.expectExit(expectedCode)
+					.build()
+					.runAndAssert();
+		} else {
+			AwkTestSupport
+					.awkTest("BWK.t " + awkName)
+					.script(awkPath)
+					.operand(inputPath.toString())
+					.expectLines(okPath)
+					.expectExit(expectedCode)
+					.build()
+					.runAndAssert();
+		}
 	}
 
 	/**
-	 * Finalizes the BWK.p integration suite.
+	 * Finalizes the BWK.t integration suite.
 	 *
 	 * @throws Exception unused hook retained for suite symmetry
 	 */

--- a/src/it/java/io/jawk/posix/PosixIT.java
+++ b/src/it/java/io/jawk/posix/PosixIT.java
@@ -1,4 +1,4 @@
-package io.jawk;
+package io.jawk.posix;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -22,12 +22,20 @@ package io.jawk;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import io.jawk.AwkTestSupport;
 import java.util.Locale;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class AwkMan7Test {
+/**
+ * Integration suite for POSIX AWK behavior, expressed as explicit Jawk tests
+ * derived from the POSIX awk utility specification.
+ *
+ * @see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html">POSIX awk utility
+ *      specification</a>
+ */
+public class PosixIT {
 
 	private static Locale defaultLocale;
 
@@ -952,8 +960,8 @@ public class AwkMan7Test {
 	public void spec92EnvironExposesEnvironmentVariable() throws Exception {
 		AwkTestSupport
 				.awkTest("92. ENVIRON exposes environment variable")
-				.script("BEGIN{print ENVIRON[\"AWK_TEST\"]}")
-				.expectLines(System.getenv().getOrDefault("AWK_TEST", ""))
+				.script("BEGIN{print ENVIRON[\"PATH\"]}")
+				.expectLines(System.getenv().getOrDefault("PATH", ""))
 				.runAndAssert();
 	}
 

--- a/src/site/markdown/compatibility.md
+++ b/src/site/markdown/compatibility.md
@@ -32,7 +32,7 @@ This maintained fork diverges from the original project in several practical way
 - Jawk supports long integers
 - Jawk supports octal and hexadecimal notation in strings
 - the Maven coordinates are `io.jawk:jawk` and the package root is `io.jawk`
-- gawk and bwk compatibility test suites have been added
+- BWK, POSIX, and gawk compatibility test suites have been added
 - the Maven artifact is published under the LGPL
 - operator precedence is fixed and follows POSIX specifications
 
@@ -74,10 +74,17 @@ Jawk tuples are reusable, but they should be treated as internal artifacts tied 
 
 ## Compatibility Test Suites
 
-Jawk maintains compatibility tests derived from the BWK (One True AWK) and gawk test suites. These run automatically as integration tests during `mvn verify`.
+Jawk maintains compatibility tests derived from:
+
+- BWK / One True Awk: <https://github.com/onetrueawk/awk>
+- POSIX awk utility specification: <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html>
+- GNU Awk: `git://git.savannah.gnu.org/gawk.git`
+
+These run automatically as integration tests during `mvn verify`.
 
 Compatibility suites now live under `src/it/java`, with their vendored inputs under `src/it/resources`.
 The compatibility suites read those vendored files directly from the repository checkout instead of relying on the Maven test classpath layout.
+They are also grouped by upstream family in separate Java packages so the Failsafe reports aggregate BWK, POSIX, and gawk results independently.
 The gawk coverage is split into a small set of explicit Java integration suites built on `AwkTestSupport`, following the broad test families declared in gawk's vendored `Makefile.am`. The vendored gawk files remain in the repository to make future refreshes and diffs straightforward, but the runtime source of truth is the Java test code.
 
 | Suite | Coverage |
@@ -85,6 +92,7 @@ The gawk coverage is split into a small set of explicit Java integration suites 
 | **BwkPIT** | Pattern matching and basic AWK operations from the BWK test collection |
 | **BwkTIT** | Text processing, field splitting, built-in functions, and output formatting |
 | **BwkMiscIT** | Miscellaneous BWK compatibility edge cases |
+| **PosixIT** | Explicit POSIX AWK specification behaviors transcribed into integration tests |
 | **GawkIT** | Core gawk compatibility mirrored from the vendored basic and Unix test groups |
 | **GawkExtensionIT** | gawk extension-oriented compatibility mirrored from the vendored extension-style test groups |
 | **GawkLocaleIT** | Locale- and charset-sensitive gawk compatibility mirrored from the vendored locale test groups |


### PR DESCRIPTION
﻿## What changed

This PR groups the compatibility integration suites by upstream family so the Failsafe report aggregates results more clearly.

- moved the BWK suites into `io.jawk.onetrueawk`
- moved the gawk suites into `io.jawk.gawk`
- moved the POSIX suite into `io.jawk.posix` as `PosixIT`
- made `CompatibilityTestResources` a small shared helper across those packages
- updated the compatibility documentation to describe the new grouping

## Why

The compatibility suites now come from three distinct upstream sources: BWK / One True Awk, the POSIX awk specification, and GNU Awk. Grouping them by package makes the Failsafe and site reports easier to read and keeps the code structure aligned with those sources.

## Impact

- `mvn test` still excludes the compatibility suites
- `mvn verify` still runs them under Failsafe
- Failsafe reports now group results under `io.jawk.onetrueawk.*`, `io.jawk.posix.*`, and `io.jawk.gawk.*`

## Validation

- `mvn license:update-file-header`
- `mvn formatter:format`
- `mvn test`
- `mvn verify`
