### PR TITLE
Add full support for Persistent Memory in Cli and gawk-style memory file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Jawk is a pure Java implementation of [AWK](https://en.wikipedia.org/wiki/AWK). 
 echo "hello world" | java -jar jawk-${project.version}-standalone.jar '{ print $2 ", " $1 "!" }'
 ```
 
+For gawk-style persistent globals across separate CLI invocations, use `--persist state.bin` or set the `JAWK_PERSISTENT_MEMORY` environment variable to a state file path. Jawk reloads the retained user-defined globals from that file before execution and writes them back after the run finishes.
+
 ## Java Example
 
 ```java

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ String result = awk.script("{ print toupper($0) }").input("hello world").execute
 ```
 
 When writing custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values rather than concrete map implementations.
+If you embed Jawk through [`AVM`](https://jawk.io/apidocs/io/jawk/backend/AVM.html), use `executePersistingGlobals(...)` when you want user-defined globals to survive across sequential runs on the same runtime instance.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Jawk is a pure Java implementation of [AWK](https://en.wikipedia.org/wiki/AWK). 
 echo "hello world" | java -jar jawk-${project.version}-standalone.jar '{ print $2 ", " $1 "!" }'
 ```
 
-For gawk-style persistent globals across separate CLI invocations, use `--persist state.bin` or set the `JAWK_PERSISTENT_MEMORY` environment variable to a state file path. Jawk reloads the retained user-defined globals from that file before execution and writes them back after the run finishes.
-
 ## Java Example
 
 ```java
@@ -24,7 +22,6 @@ String result = awk.script("{ print toupper($0) }").input("hello world").execute
 ```
 
 When writing custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values rather than concrete map implementations.
-If you embed Jawk through [`AVM`](https://jawk.io/apidocs/io/jawk/backend/AVM.html), use `executePersistingGlobals(...)` when you want user-defined globals to survive across sequential runs on the same runtime instance.
 
 ## Documentation
 

--- a/src/it/java/io/jawk/gawk/GawkOptionalFeatureIT.java
+++ b/src/it/java/io/jawk/gawk/GawkOptionalFeatureIT.java
@@ -22,6 +22,11 @@ package io.jawk.gawk;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 import io.jawk.AwkTestSupport;
 import org.junit.Test;
 
@@ -597,7 +602,28 @@ public class GawkOptionalFeatureIT extends AbstractGawkSuite {
 
 	@Test
 	public void test_pma() throws Exception {
-		skip(MANUAL_SKIP_REASON);
+		Path memoryFile = Files.createTempFile("jawk-pma-", ".bin");
+		Files.deleteIfExists(memoryFile);
+		try {
+			AwkTestSupport
+					.cliTest("GAWK pma first run")
+					.environmentVariable("JAWK_PERSISTENT_MEMORY", memoryFile.toString())
+					.script("BEGIN { print ++i }")
+					.expect("1\n")
+					.expectExit(0)
+					.runAndAssert();
+			assertTrue(Files.isRegularFile(memoryFile));
+			AwkTestSupport
+					.cliTest("GAWK pma second run")
+					.environmentVariable("JAWK_PERSISTENT_MEMORY", memoryFile.toString())
+					.script("BEGIN { print ++i }")
+					.expect("2\n")
+					.expectExit(0)
+					.runAndAssert();
+			assertEquals("1\n2\n", gawkText("pma.ok").replace("\r\n", "\n"));
+		} finally {
+			Files.deleteIfExists(memoryFile);
+		}
 	}
 
 	@Test

--- a/src/it/java/io/jawk/gawk/GawkOptionalFeatureIT.java
+++ b/src/it/java/io/jawk/gawk/GawkOptionalFeatureIT.java
@@ -607,7 +607,7 @@ public class GawkOptionalFeatureIT extends AbstractGawkSuite {
 		try {
 			AwkTestSupport
 					.cliTest("GAWK pma first run")
-					.environmentVariable("JAWK_PERSISTENT_MEMORY", memoryFile.toString())
+					.env("JAWK_PERSISTENT_MEMORY", memoryFile.toString())
 					.script("BEGIN { print ++i }")
 					.expect("1\n")
 					.expectExit(0)
@@ -615,7 +615,7 @@ public class GawkOptionalFeatureIT extends AbstractGawkSuite {
 			assertTrue(Files.isRegularFile(memoryFile));
 			AwkTestSupport
 					.cliTest("GAWK pma second run")
-					.environmentVariable("JAWK_PERSISTENT_MEMORY", memoryFile.toString())
+					.env("JAWK_PERSISTENT_MEMORY", memoryFile.toString())
 					.script("BEGIN { print ++i }")
 					.expect("2\n")
 					.expectExit(0)

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -23,6 +23,8 @@ package io.jawk;
  */
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.jawk.backend.AVM;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -44,6 +46,8 @@ import io.jawk.ext.JawkExtension;
 import io.jawk.ext.StdinExtension;
 import io.jawk.frontend.AstNode;
 import io.jawk.jrt.AwkRuntimeException;
+import io.jawk.jrt.OutputStreamAwkSink;
+import io.jawk.jrt.StreamInputSource;
 import io.jawk.util.AwkSettings;
 import io.jawk.util.ScriptFileSource;
 import io.jawk.util.ScriptSource;
@@ -55,6 +59,7 @@ public final class Cli {
 
 	private static final String JAR_NAME;
 	private static final String POSIX_LOAD_CONFLICT_MESSAGE = "--posix cannot be combined with -L because -L loads a precompiled program.";
+	private static final String PERSISTENT_MEMORY_ENVIRONMENT_VARIABLE = "JAWK_PERSISTENT_MEMORY";
 
 	static {
 		String myName;
@@ -71,6 +76,7 @@ public final class Cli {
 	private final PrintStream out;
 	private final PrintStream err;
 	private final InputStream inputStream;
+	private final Map<String, String> environment;
 	private final List<String> nameValueOrFileNames = new ArrayList<String>();
 
 	private final List<ScriptSource> scriptSources = new ArrayList<ScriptSource>();
@@ -84,12 +90,13 @@ public final class Cli {
 	private boolean printUsage;
 	private boolean sandbox;
 	private boolean disableOptimize;
+	private File persistentMemoryFile;
 
 	/**
 	 * Creates a CLI instance wired to the standard input and output streams.
 	 */
 	public Cli() {
-		this(System.in, System.out, System.err);
+		this(System.in, System.out, System.err, System.getenv());
 	}
 
 	/**
@@ -99,11 +106,27 @@ public final class Cli {
 	 * @param out stream where program output is written
 	 * @param err stream where error messages could be written
 	 */
-	@SuppressFBWarnings("EI_EXPOSE_REP2")
 	public Cli(InputStream in, PrintStream out, PrintStream err) {
+		this(in, out, err, System.getenv());
+	}
+
+	/**
+	 * Creates a CLI instance using the supplied streams and environment variables.
+	 * <p>
+	 * This constructor exists primarily for tests and embedded launchers that need
+	 * deterministic control over environment-driven options such as
+	 * {@value #PERSISTENT_MEMORY_ENVIRONMENT_VARIABLE}.
+	 *
+	 * @param in stream from which program input is read
+	 * @param out stream where program output is written
+	 * @param err stream where error messages could be written
+	 * @param environment environment variables visible to this CLI instance
+	 */
+	Cli(InputStream in, PrintStream out, PrintStream err, Map<String, String> environment) {
 		this.out = out;
 		this.inputStream = in;
 		this.err = err != null ? err : System.err;
+		this.environment = environment != null ? environment : System.getenv();
 	}
 
 	/**
@@ -213,6 +236,10 @@ public final class Cli {
 							"Failed to read program '" + file + "': " + ex.getMessage(),
 							ex);
 				}
+			} else if (arg.equals("--persist")) {
+				// --persist filename : load and save persistent user globals
+				checkParameterHasArgument(args, argIdx);
+				persistentMemoryFile = new File(args[++argIdx]);
 			} else if (arg.equals("-l") || arg.equals("--load")) {
 				// -l/--load extension : load extension
 				checkParameterHasArgument(args, argIdx);
@@ -400,8 +427,149 @@ public final class Cli {
 			// If only dumping information, no need to execute the script
 			return;
 		}
-		// Finally run the compiled program with the input and arguments.
-		awk.script(program).input(inputStream).arguments(nameValueOrFileNames).errorStream(err).execute(out);
+		executeProgram(awk, program, resolvePersistentMemoryFile());
+	}
+
+	/**
+	 * Resolves the persistent-memory backing file from the command line or
+	 * environment.
+	 * <p>
+	 * The dedicated {@code --persist} option takes precedence over the
+	 * {@value #PERSISTENT_MEMORY_ENVIRONMENT_VARIABLE} environment variable.
+	 *
+	 * @return resolved persistent-memory file, or {@code null} when persistence
+	 *         was not requested
+	 */
+	private File resolvePersistentMemoryFile() {
+		if (persistentMemoryFile != null) {
+			return persistentMemoryFile;
+		}
+		String configuredPath = environment.get(PERSISTENT_MEMORY_ENVIRONMENT_VARIABLE);
+		if (configuredPath == null || configuredPath.trim().isEmpty()) {
+			return null;
+		}
+		return new File(configuredPath);
+	}
+
+	/**
+	 * Executes the compiled program through one AVM setup path, optionally loading
+	 * and saving persistent user-defined globals when a backing file was
+	 * configured.
+	 *
+	 * @param awk engine used to create the runtime
+	 * @param program compiled program to execute
+	 * @param memoryFile persistent-memory file, or {@code null} for normal
+	 *        execution
+	 * @throws Exception if runtime setup, execution, or persistence fails
+	 */
+	private void executeProgram(Awk awk, AwkProgram program, File memoryFile) throws Exception {
+		OutputStreamAwkSink sink = new OutputStreamAwkSink(out, settings.getLocale());
+		try (AVM avm = awk.createAvm()) {
+			avm.setAwkSink(sink);
+			avm.setErrorStream(err);
+			if (memoryFile != null) {
+				restorePersistentMemoryIfPresent(avm, memoryFile);
+			}
+			StreamInputSource resolvedSource = new StreamInputSource(resolveExecutionInputStream(), avm, avm.getJrt());
+			try {
+				executeOnPreparedAvm(avm, program, resolvedSource, memoryFile != null);
+			} finally {
+				if (memoryFile != null) {
+					savePersistentMemory(avm, memoryFile);
+				}
+				sink.flush();
+			}
+		}
+	}
+
+	/**
+	 * Creates the CLI input stream used for the current execution.
+	 *
+	 * @return input stream to feed into the runtime
+	 */
+	private InputStream resolveExecutionInputStream() {
+		return inputStream != null ? inputStream : new ByteArrayInputStream(new byte[0]);
+	}
+
+	/**
+	 * Executes a compiled program on an already configured AVM.
+	 *
+	 * @param avm configured runtime instance
+	 * @param program compiled program to execute
+	 * @param resolvedSource input source bound to the current runtime
+	 * @param persistGlobals whether persistent globals should be merged across runs
+	 * @throws ExitException when the program exits with a non-zero status
+	 * @throws IOException if execution fails
+	 */
+	private void executeOnPreparedAvm(
+			AVM avm,
+			AwkProgram program,
+			StreamInputSource resolvedSource,
+			boolean persistGlobals)
+			throws ExitException,
+			IOException {
+		try {
+			if (persistGlobals) {
+				avm.executePersistingGlobals(program, resolvedSource, nameValueOrFileNames, null);
+			} else {
+				avm.execute(program, resolvedSource, nameValueOrFileNames, null);
+			}
+		} catch (ExitException ex) {
+			if (ex.getCode() != 0) {
+				throw ex;
+			}
+		}
+	}
+
+	/**
+	 * Restores persistent user-defined globals from the specified file when it
+	 * already exists.
+	 *
+	 * @param avm runtime into which the persistent memory should be restored
+	 * @param memoryFile file containing the serialized persistent snapshot
+	 */
+	private static void restorePersistentMemoryIfPresent(AVM avm, File memoryFile) {
+		if (!memoryFile.exists()) {
+			return;
+		}
+		if (!memoryFile.isFile()) {
+			throw new IllegalArgumentException(
+					"Persistent memory path '" + memoryFile + "' exists but is not a regular file.");
+		}
+		try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(memoryFile))) {
+			avm.restorePersistentMemory((AVM.PersistentMemorySnapshot) ois.readObject());
+		} catch (java.io.InvalidClassException ex) {
+			throw new IllegalArgumentException(
+					"Persistent memory file '" + memoryFile + "' is not compatible with this version ("
+							+ ex.getMessage()
+							+ "). Please discard it and rerun.",
+					ex);
+		} catch (ClassCastException ex) {
+			throw new IllegalArgumentException(
+					"File '" + memoryFile + "' does not contain valid Jawk persistent memory.",
+					ex);
+		} catch (IOException | ClassNotFoundException ex) {
+			throw new IllegalArgumentException(
+					"Failed to read persistent memory '" + memoryFile + "': " + ex.getMessage(),
+					ex);
+		}
+	}
+
+	/**
+	 * Saves the AVM's current persistent user-global bank to the specified file.
+	 *
+	 * @param avm runtime whose persistent memory should be saved
+	 * @param memoryFile destination file
+	 * @throws IOException if the snapshot cannot be written
+	 */
+	private static void savePersistentMemory(AVM avm, File memoryFile) throws IOException {
+		File parent = memoryFile.getAbsoluteFile().getParentFile();
+		if (parent != null && !parent.isDirectory() && !parent.mkdirs() && !parent.isDirectory()) {
+			throw new IOException("Failed to create directory '" + parent + "' for persistent memory.");
+		}
+		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(memoryFile))) {
+			oos.writeObject(avm.snapshotPersistentMemory());
+		}
 	}
 
 	/**
@@ -418,6 +586,7 @@ public final class Cli {
 								" [-F fs_val]" +
 								" [-f script-filename]" +
 								" [-L program-filename]" +
+								" [--persist memory-file]" +
 								" [-K program-filename]" +
 								" [-S|--sandbox]" +
 								" [--posix]" +
@@ -436,6 +605,13 @@ public final class Cli {
 		dest.println(" -F fs_val = Use fs_val for FS.");
 		dest.println(" -f filename = Use contents of filename for script.");
 		dest.println(" -L filename = Load precompiled program from filename.");
+		dest
+				.println(
+						" --persist filename = Load and save persistent user-defined globals from filename.");
+		dest
+				.println(
+						"                      When omitted, the " + PERSISTENT_MEMORY_ENVIRONMENT_VARIABLE
+								+ " environment variable can provide the backing file path.");
 		dest.println(" -l extension = Load an extension by extension name or class name.");
 		dest.println(" --load extension = Same as -l.");
 		dest.println("                      Extensions must already be on the class path before loading them.");
@@ -493,7 +669,6 @@ public final class Cli {
 	 *
 	 * @param args command-line arguments
 	 */
-	@SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE", justification = "let PrintStream decide line separator")
 	public static void main(String[] args) {
 		try {
 			Cli cli = new Cli();
@@ -503,9 +678,9 @@ public final class Cli {
 			System.exit(e.getCode());
 		} catch (AwkRuntimeException e) {
 			if (e.getLineNumber() >= 0) {
-				System.err.printf("%s (line %d): %s\n", e.getClass().getSimpleName(), e.getLineNumber(), e.getMessage());
+				System.err.printf("%s (line %d): %s%n", e.getClass().getSimpleName(), e.getLineNumber(), e.getMessage());
 			} else {
-				System.err.printf("%s: %s\n", e.getClass().getSimpleName(), e.getMessage());
+				System.err.printf("%s: %s%n", e.getClass().getSimpleName(), e.getMessage());
 			}
 			System.exit(1);
 		} catch (IllegalArgumentException e) {
@@ -513,7 +688,7 @@ public final class Cli {
 			e.printStackTrace(System.err);
 			System.exit(1);
 		} catch (Exception e) {
-			System.err.printf("%s: %s\n", e.getClass().getSimpleName(), e.getMessage());
+			System.err.printf("%s: %s%n", e.getClass().getSimpleName(), e.getMessage());
 			System.exit(1);
 		}
 	}

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -473,16 +473,14 @@ public final class Cli {
 			InputStream runtimeInput = inputStream != null ? inputStream : new ByteArrayInputStream(new byte[0]);
 			StreamInputSource resolvedSource = new StreamInputSource(runtimeInput, avm, avm.getJrt());
 			try {
-				try {
-					if (memoryFile != null) {
-						avm.executePersistingGlobals(program, resolvedSource, nameValueOrFileNames, null);
-					} else {
-						avm.execute(program, resolvedSource, nameValueOrFileNames, null);
-					}
-				} catch (ExitException ex) {
-					if (ex.getCode() != 0) {
-						throw ex;
-					}
+				if (memoryFile != null) {
+					avm.executePersistingGlobals(program, resolvedSource, nameValueOrFileNames, null);
+				} else {
+					avm.execute(program, resolvedSource, nameValueOrFileNames, null);
+				}
+			} catch (ExitException ex) {
+				if (ex.getCode() != 0) {
+					throw ex;
 				}
 			} finally {
 				if (memoryFile != null) {

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -24,29 +24,43 @@ package io.jawk;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jawk.backend.AVM;
+import io.jawk.intermediate.UninitializedObject;
+import io.jawk.jrt.HashAssocArray;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InvalidClassException;
 import java.io.InputStream;
+import java.io.ObjectStreamClass;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import io.jawk.ext.ExtensionRegistry;
 import io.jawk.ext.JawkExtension;
 import io.jawk.ext.StdinExtension;
 import io.jawk.frontend.AstNode;
 import io.jawk.jrt.AwkRuntimeException;
 import io.jawk.jrt.OutputStreamAwkSink;
+import io.jawk.jrt.SortedAssocArray;
 import io.jawk.jrt.StreamInputSource;
 import io.jawk.util.AwkSettings;
 import io.jawk.util.ScriptFileSource;
@@ -60,6 +74,26 @@ public final class Cli {
 	private static final String JAR_NAME;
 	private static final String POSIX_LOAD_CONFLICT_MESSAGE = "--posix cannot be combined with -L because -L loads a precompiled program.";
 	private static final String PERSISTENT_MEMORY_ENVIRONMENT_VARIABLE = "JAWK_PERSISTENT_MEMORY";
+	private static final Set<String> PERSISTENT_MEMORY_ALLOWED_CLASS_NAMES = Collections
+			.unmodifiableSet(
+					new LinkedHashSet<String>(
+							Arrays
+									.asList(
+											LinkedHashMap.class.getName(),
+											java.util.HashMap.class.getName(),
+											java.util.TreeMap.class.getName(),
+											HashAssocArray.class.getName(),
+											SortedAssocArray.class.getName(),
+											String.class.getName(),
+											Number.class.getName(),
+											Integer.class.getName(),
+											Long.class.getName(),
+											Double.class.getName(),
+											Float.class.getName(),
+											Short.class.getName(),
+											Byte.class.getName(),
+											Boolean.class.getName(),
+											UninitializedObject.class.getName())));
 
 	static {
 		String myName;
@@ -126,7 +160,9 @@ public final class Cli {
 		this.out = out;
 		this.inputStream = in;
 		this.err = err != null ? err : System.err;
-		this.environment = environment != null ? environment : System.getenv();
+		this.environment = environment != null ?
+				Collections.unmodifiableMap(new LinkedHashMap<String, String>(environment)) :
+				System.getenv();
 	}
 
 	/**
@@ -222,7 +258,7 @@ public final class Cli {
 				String file = args[++argIdx];
 				try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
 					precompiledProgram = (AwkProgram) ois.readObject();
-				} catch (java.io.InvalidClassException ex) {
+				} catch (InvalidClassException ex) {
 					throw new IllegalArgumentException(
 							"Precompiled program '" + file + "' is not compatible with this version (" + ex.getMessage()
 									+ "). Please recompile.",
@@ -506,15 +542,16 @@ public final class Cli {
 			throw new IllegalArgumentException(
 					"Persistent memory path '" + memoryFile + "' exists but is not a regular file.");
 		}
-		try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(memoryFile))) {
+		try (ObjectInputStream ois = new PersistentMemoryObjectInputStream(new FileInputStream(memoryFile))) {
 			@SuppressWarnings("unchecked")
 			Map<String, Object> snapshot = (Map<String, Object>) ois.readObject();
 			avm.restorePersistentMemory(snapshot);
-		} catch (java.io.InvalidClassException ex) {
+		} catch (InvalidClassException ex) {
 			throw new IllegalArgumentException(
-					"Persistent memory file '" + memoryFile + "' is not compatible with this version ("
+					"Persistent memory file '" + memoryFile
+							+ "' is not compatible with this version or does not contain valid Jawk persistent memory ("
 							+ ex.getMessage()
-							+ "). Please discard it and rerun.",
+							+ ").",
 					ex);
 		} catch (ClassCastException ex) {
 			throw new IllegalArgumentException(
@@ -535,12 +572,56 @@ public final class Cli {
 	 * @throws IOException if the snapshot cannot be written
 	 */
 	private static void savePersistentMemory(AVM avm, File memoryFile) throws IOException {
-		File parent = memoryFile.getAbsoluteFile().getParentFile();
-		if (parent != null && !parent.isDirectory() && !parent.mkdirs() && !parent.isDirectory()) {
-			throw new IOException("Failed to create directory '" + parent + "' for persistent memory.");
+		Path targetPath = memoryFile.toPath().toAbsolutePath();
+		Path parentPath = targetPath.getParent();
+		Path tempDirectory = parentPath != null ? parentPath : targetPath.toAbsolutePath().getRoot();
+		if (tempDirectory == null) {
+			tempDirectory = new File(".").getAbsoluteFile().toPath();
 		}
-		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(memoryFile))) {
-			oos.writeObject(avm.snapshotPersistentMemory());
+		Files.createDirectories(tempDirectory);
+		Path targetFileName = targetPath.getFileName();
+		String tempPrefix;
+		if (targetFileName == null) {
+			tempPrefix = "jawk";
+		} else {
+			tempPrefix = targetFileName.toString();
+		}
+		if (tempPrefix.length() < 3) {
+			tempPrefix = (tempPrefix + "___").substring(0, 3);
+		}
+		Path tempFile = Files.createTempFile(tempDirectory, tempPrefix, ".tmp");
+		try {
+			try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(tempFile.toFile()))) {
+				oos.writeObject(avm.snapshotPersistentMemory());
+			}
+			try {
+				Files.move(tempFile, targetPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+			} catch (AtomicMoveNotSupportedException ex) {
+				Files.move(tempFile, targetPath, StandardCopyOption.REPLACE_EXISTING);
+			}
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
+	}
+
+	private static final class PersistentMemoryObjectInputStream extends ObjectInputStream {
+
+		private PersistentMemoryObjectInputStream(InputStream in) throws IOException {
+			super(in);
+		}
+
+		@Override
+		protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+			String className = desc.getName();
+			if (!PERSISTENT_MEMORY_ALLOWED_CLASS_NAMES.contains(className)) {
+				throw new InvalidClassException(className, "Unsupported persistent memory type");
+			}
+			return super.resolveClass(desc);
+		}
+
+		@Override
+		protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+			throw new InvalidClassException("Proxy classes are not supported in Jawk persistent memory");
 		}
 	}
 

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -24,43 +24,29 @@ package io.jawk;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jawk.backend.AVM;
-import io.jawk.intermediate.UninitializedObject;
-import io.jawk.jrt.HashAssocArray;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InvalidClassException;
 import java.io.InputStream;
-import java.io.ObjectStreamClass;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import io.jawk.ext.ExtensionRegistry;
 import io.jawk.ext.JawkExtension;
 import io.jawk.ext.StdinExtension;
 import io.jawk.frontend.AstNode;
 import io.jawk.jrt.AwkRuntimeException;
 import io.jawk.jrt.OutputStreamAwkSink;
-import io.jawk.jrt.SortedAssocArray;
 import io.jawk.jrt.StreamInputSource;
 import io.jawk.util.AwkSettings;
 import io.jawk.util.ScriptFileSource;
@@ -74,26 +60,6 @@ public final class Cli {
 	private static final String JAR_NAME;
 	private static final String POSIX_LOAD_CONFLICT_MESSAGE = "--posix cannot be combined with -L because -L loads a precompiled program.";
 	private static final String PERSISTENT_MEMORY_ENVIRONMENT_VARIABLE = "JAWK_PERSISTENT_MEMORY";
-	private static final Set<String> PERSISTENT_MEMORY_ALLOWED_CLASS_NAMES = Collections
-			.unmodifiableSet(
-					new LinkedHashSet<String>(
-							Arrays
-									.asList(
-											LinkedHashMap.class.getName(),
-											java.util.HashMap.class.getName(),
-											java.util.TreeMap.class.getName(),
-											HashAssocArray.class.getName(),
-											SortedAssocArray.class.getName(),
-											String.class.getName(),
-											Number.class.getName(),
-											Integer.class.getName(),
-											Long.class.getName(),
-											Double.class.getName(),
-											Float.class.getName(),
-											Short.class.getName(),
-											Byte.class.getName(),
-											Boolean.class.getName(),
-											UninitializedObject.class.getName())));
 
 	static {
 		String myName;
@@ -160,9 +126,7 @@ public final class Cli {
 		this.out = out;
 		this.inputStream = in;
 		this.err = err != null ? err : System.err;
-		this.environment = environment != null ?
-				Collections.unmodifiableMap(new LinkedHashMap<String, String>(environment)) :
-				System.getenv();
+		this.environment = environment != null ? environment : System.getenv();
 	}
 
 	/**
@@ -258,7 +222,7 @@ public final class Cli {
 				String file = args[++argIdx];
 				try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
 					precompiledProgram = (AwkProgram) ois.readObject();
-				} catch (InvalidClassException ex) {
+				} catch (java.io.InvalidClassException ex) {
 					throw new IllegalArgumentException(
 							"Precompiled program '" + file + "' is not compatible with this version (" + ex.getMessage()
 									+ "). Please recompile.",
@@ -542,16 +506,15 @@ public final class Cli {
 			throw new IllegalArgumentException(
 					"Persistent memory path '" + memoryFile + "' exists but is not a regular file.");
 		}
-		try (ObjectInputStream ois = new PersistentMemoryObjectInputStream(new FileInputStream(memoryFile))) {
+		try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(memoryFile))) {
 			@SuppressWarnings("unchecked")
 			Map<String, Object> snapshot = (Map<String, Object>) ois.readObject();
 			avm.restorePersistentMemory(snapshot);
-		} catch (InvalidClassException ex) {
+		} catch (java.io.InvalidClassException ex) {
 			throw new IllegalArgumentException(
-					"Persistent memory file '" + memoryFile
-							+ "' is not compatible with this version or does not contain valid Jawk persistent memory ("
+					"Persistent memory file '" + memoryFile + "' is not compatible with this version ("
 							+ ex.getMessage()
-							+ ").",
+							+ "). Please discard it and rerun.",
 					ex);
 		} catch (ClassCastException ex) {
 			throw new IllegalArgumentException(
@@ -572,56 +535,12 @@ public final class Cli {
 	 * @throws IOException if the snapshot cannot be written
 	 */
 	private static void savePersistentMemory(AVM avm, File memoryFile) throws IOException {
-		Path targetPath = memoryFile.toPath().toAbsolutePath();
-		Path parentPath = targetPath.getParent();
-		Path tempDirectory = parentPath != null ? parentPath : targetPath.toAbsolutePath().getRoot();
-		if (tempDirectory == null) {
-			tempDirectory = new File(".").getAbsoluteFile().toPath();
+		File parent = memoryFile.getAbsoluteFile().getParentFile();
+		if (parent != null && !parent.isDirectory() && !parent.mkdirs() && !parent.isDirectory()) {
+			throw new IOException("Failed to create directory '" + parent + "' for persistent memory.");
 		}
-		Files.createDirectories(tempDirectory);
-		Path targetFileName = targetPath.getFileName();
-		String tempPrefix;
-		if (targetFileName == null) {
-			tempPrefix = "jawk";
-		} else {
-			tempPrefix = targetFileName.toString();
-		}
-		if (tempPrefix.length() < 3) {
-			tempPrefix = (tempPrefix + "___").substring(0, 3);
-		}
-		Path tempFile = Files.createTempFile(tempDirectory, tempPrefix, ".tmp");
-		try {
-			try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(tempFile.toFile()))) {
-				oos.writeObject(avm.snapshotPersistentMemory());
-			}
-			try {
-				Files.move(tempFile, targetPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-			} catch (AtomicMoveNotSupportedException ex) {
-				Files.move(tempFile, targetPath, StandardCopyOption.REPLACE_EXISTING);
-			}
-		} finally {
-			Files.deleteIfExists(tempFile);
-		}
-	}
-
-	private static final class PersistentMemoryObjectInputStream extends ObjectInputStream {
-
-		private PersistentMemoryObjectInputStream(InputStream in) throws IOException {
-			super(in);
-		}
-
-		@Override
-		protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
-			String className = desc.getName();
-			if (!PERSISTENT_MEMORY_ALLOWED_CLASS_NAMES.contains(className)) {
-				throw new InvalidClassException(className, "Unsupported persistent memory type");
-			}
-			return super.resolveClass(desc);
-		}
-
-		@Override
-		protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
-			throw new InvalidClassException("Proxy classes are not supported in Jawk persistent memory");
+		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(memoryFile))) {
+			oos.writeObject(avm.snapshotPersistentMemory());
 		}
 	}
 

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -125,6 +125,8 @@ public final class Cli {
 	 * @param environment environment variables visible to this CLI instance
 	 */
 	Cli(InputStream in, PrintStream out, PrintStream err, Map<String, String> environment) {
+		// Keep the caller-provided streams live so the CLI reads and writes directly
+		// against the requested endpoints during execution.
 		this.out = out;
 		this.inputStream = in;
 		this.err = err != null ? err : System.err;
@@ -487,10 +489,10 @@ public final class Cli {
 					throw ex;
 				}
 			} finally {
+				sink.flush();
 				if (memoryFile != null) {
 					savePersistentMemory(avm, memoryFile);
 				}
-				sink.flush();
 			}
 		}
 	}

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -35,6 +35,8 @@ import java.io.ObjectOutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -126,7 +128,9 @@ public final class Cli {
 		this.out = out;
 		this.inputStream = in;
 		this.err = err != null ? err : System.err;
-		this.environment = environment != null ? environment : System.getenv();
+		this.environment = environment != null ?
+				Collections.unmodifiableMap(new LinkedHashMap<String, String>(environment)) :
+				System.getenv();
 	}
 
 	/**

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -470,53 +470,25 @@ public final class Cli {
 			if (memoryFile != null) {
 				restorePersistentMemoryIfPresent(avm, memoryFile);
 			}
-			StreamInputSource resolvedSource = new StreamInputSource(resolveExecutionInputStream(), avm, avm.getJrt());
+			InputStream runtimeInput = inputStream != null ? inputStream : new ByteArrayInputStream(new byte[0]);
+			StreamInputSource resolvedSource = new StreamInputSource(runtimeInput, avm, avm.getJrt());
 			try {
-				executeOnPreparedAvm(avm, program, resolvedSource, memoryFile != null);
+				try {
+					if (memoryFile != null) {
+						avm.executePersistingGlobals(program, resolvedSource, nameValueOrFileNames, null);
+					} else {
+						avm.execute(program, resolvedSource, nameValueOrFileNames, null);
+					}
+				} catch (ExitException ex) {
+					if (ex.getCode() != 0) {
+						throw ex;
+					}
+				}
 			} finally {
 				if (memoryFile != null) {
 					savePersistentMemory(avm, memoryFile);
 				}
 				sink.flush();
-			}
-		}
-	}
-
-	/**
-	 * Creates the CLI input stream used for the current execution.
-	 *
-	 * @return input stream to feed into the runtime
-	 */
-	private InputStream resolveExecutionInputStream() {
-		return inputStream != null ? inputStream : new ByteArrayInputStream(new byte[0]);
-	}
-
-	/**
-	 * Executes a compiled program on an already configured AVM.
-	 *
-	 * @param avm configured runtime instance
-	 * @param program compiled program to execute
-	 * @param resolvedSource input source bound to the current runtime
-	 * @param persistGlobals whether persistent globals should be merged across runs
-	 * @throws ExitException when the program exits with a non-zero status
-	 * @throws IOException if execution fails
-	 */
-	private void executeOnPreparedAvm(
-			AVM avm,
-			AwkProgram program,
-			StreamInputSource resolvedSource,
-			boolean persistGlobals)
-			throws ExitException,
-			IOException {
-		try {
-			if (persistGlobals) {
-				avm.executePersistingGlobals(program, resolvedSource, nameValueOrFileNames, null);
-			} else {
-				avm.execute(program, resolvedSource, nameValueOrFileNames, null);
-			}
-		} catch (ExitException ex) {
-			if (ex.getCode() != 0) {
-				throw ex;
 			}
 		}
 	}
@@ -537,7 +509,9 @@ public final class Cli {
 					"Persistent memory path '" + memoryFile + "' exists but is not a regular file.");
 		}
 		try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(memoryFile))) {
-			avm.restorePersistentMemory((AVM.PersistentMemorySnapshot) ois.readObject());
+			@SuppressWarnings("unchecked")
+			Map<String, Object> snapshot = (Map<String, Object>) ois.readObject();
+			avm.restorePersistentMemory(snapshot);
 		} catch (java.io.InvalidClassException ex) {
 			throw new IllegalArgumentException(
 					"Persistent memory file '" + memoryFile + "' is not compatible with this version ("

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -25,6 +25,8 @@ package io.jawk.backend;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -445,7 +447,7 @@ public class AVM implements VariableManager, Closeable {
 	 * @return serializable snapshot of the persistent user-global bank
 	 */
 	public Map<String, Object> snapshotPersistentMemory() {
-		return new LinkedHashMap<String, Object>(collectPersistentGlobalValues());
+		return new LinkedHashMap<>(collectPersistentGlobalValues());
 	}
 
 	/**
@@ -460,16 +462,11 @@ public class AVM implements VariableManager, Closeable {
 	 */
 	public void restorePersistentMemory(Map<String, Object> snapshot) {
 		Map<String, Object> restoredSnapshot = Objects.requireNonNull(snapshot, "snapshot");
-		Map<String, Object> restoredGlobals = new LinkedHashMap<String, Object>();
-		for (Map.Entry<String, Object> entry : restoredSnapshot.entrySet()) {
-			if (isPersistentEligibleGlobal(entry.getKey())) {
-				restoredGlobals.put(entry.getKey(), entry.getValue());
-			}
-		}
+		Map<String, Object> restoredGlobals = filterToPersistentEligible(restoredSnapshot);
 		runtimeStack.clearGlobals();
 		if (!restoredGlobals.isEmpty()) {
-			runtimeStack.rebindGlobals(new ArrayList<String>(restoredGlobals.keySet()));
-			applyNamedGlobalOverrides(restoredGlobals);
+			runtimeStack.rebindGlobals(new ArrayList<>(restoredGlobals.keySet()));
+			applyGlobalsToStack(restoredGlobals);
 		}
 		mergedGlobalLayoutActive = false;
 	}
@@ -672,9 +669,11 @@ public class AVM implements VariableManager, Closeable {
 				executionUserSeeds);
 
 		runtimeStack.rebindGlobals(mergedGlobalNamesByOffset);
-		restoreNamedGlobals(carriedGlobals);
-		seedMissingNamedGlobals(carriedGlobals, basePersistentSeeds);
-		applyNamedGlobalOverrides(executionUserSeeds);
+		applyGlobalsToStack(carriedGlobals);
+		Map<String, Object> missingSeeds = new LinkedHashMap<>(basePersistentSeeds);
+		missingSeeds.keySet().removeAll(carriedGlobals.keySet());
+		applyGlobalsToStack(missingSeeds);
+		applyGlobalsToStack(executionUserSeeds);
 		mergedGlobalLayoutActive = true;
 	}
 
@@ -764,17 +763,34 @@ public class AVM implements VariableManager, Closeable {
 			executionInitialVariables = baseInitialVariables;
 			executionSpecialVariables = baseSpecialVariables;
 		} else {
-			executionInitialVariables = new HashMap<String, Object>(baseInitialVariables);
+			executionInitialVariables = new HashMap<>(baseInitialVariables);
 			executionInitialVariables.putAll(variableOverrides);
 
 			Map<String, Object> specialOverrides = JRT.copySpecialVariables(variableOverrides);
 			if (specialOverrides.isEmpty()) {
 				executionSpecialVariables = baseSpecialVariables;
 			} else {
-				executionSpecialVariables = new HashMap<String, Object>(baseSpecialVariables);
+				executionSpecialVariables = new HashMap<>(baseSpecialVariables);
 				executionSpecialVariables.putAll(specialOverrides);
 			}
 		}
+	}
+
+	/**
+	 * Filters the given map to retain only entries whose keys are
+	 * persistent-eligible globals.
+	 *
+	 * @param source source map to filter
+	 * @return insertion-ordered map containing only persistent-eligible entries
+	 */
+	private Map<String, Object> filterToPersistentEligible(Map<String, Object> source) {
+		Map<String, Object> result = new LinkedHashMap<>();
+		for (Map.Entry<String, Object> entry : source.entrySet()) {
+			if (isPersistentEligibleGlobal(entry.getKey())) {
+				result.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return result;
 	}
 
 	/**
@@ -783,13 +799,7 @@ public class AVM implements VariableManager, Closeable {
 	 * @return retained user globals keyed by name, in current runtime order
 	 */
 	private Map<String, Object> collectPersistentGlobalValues() {
-		Map<String, Object> retainedGlobals = new LinkedHashMap<String, Object>();
-		for (Map.Entry<String, Object> entry : runtimeStack.snapshotGlobalVariables().entrySet()) {
-			if (isPersistentEligibleGlobal(entry.getKey())) {
-				retainedGlobals.put(entry.getKey(), entry.getValue());
-			}
-		}
-		return retainedGlobals;
+		return filterToPersistentEligible(runtimeStack.snapshotGlobalVariables());
 	}
 
 	/**
@@ -799,7 +809,7 @@ public class AVM implements VariableManager, Closeable {
 	 * @return baseline user globals keyed by name
 	 */
 	private Map<String, Object> collectBasePersistentGlobalSeeds() {
-		Map<String, Object> basePersistentSeeds = new LinkedHashMap<String, Object>();
+		Map<String, Object> basePersistentSeeds = new LinkedHashMap<>();
 		for (Map.Entry<String, Object> entry : baseInitialVariables.entrySet()) {
 			String name = entry.getKey();
 			if (isPersistentEligibleGlobal(name)) {
@@ -824,7 +834,7 @@ public class AVM implements VariableManager, Closeable {
 	private Map<String, Object> collectExecutionUserGlobalSeeds(
 			List<String> runtimeArguments,
 			Map<String, Object> variableOverrides) {
-		Map<String, Object> executionUserSeeds = new LinkedHashMap<String, Object>();
+		Map<String, Object> executionUserSeeds = new LinkedHashMap<>();
 		if (variableOverrides != null) {
 			for (Map.Entry<String, Object> entry : variableOverrides.entrySet()) {
 				String name = entry.getKey();
@@ -864,61 +874,26 @@ public class AVM implements VariableManager, Closeable {
 			Map<String, Object> carriedGlobals,
 			Map<String, Object> basePersistentSeeds,
 			Map<String, Object> executionUserSeeds) {
-		LinkedHashSet<String> orderedNames = new LinkedHashSet<String>();
-		List<Map.Entry<String, Integer>> compiledGlobals = new ArrayList<Map.Entry<String, Integer>>(
-				globalVariableOffsets.entrySet());
-		Collections.sort(compiledGlobals, (left, right) -> left.getValue().compareTo(right.getValue()));
+		LinkedHashSet<String> orderedNames = new LinkedHashSet<>();
+		List<Map.Entry<String, Integer>> compiledGlobals = new ArrayList<>(globalVariableOffsets.entrySet());
+		compiledGlobals.sort(java.util.Comparator.comparingInt(Map.Entry::getValue));
 		for (Map.Entry<String, Integer> entry : compiledGlobals) {
 			orderedNames.add(entry.getKey());
 		}
-		for (String name : carriedGlobals.keySet()) {
-			orderedNames.add(name);
-		}
-		for (String name : basePersistentSeeds.keySet()) {
-			orderedNames.add(name);
-		}
-		for (String name : executionUserSeeds.keySet()) {
-			orderedNames.add(name);
-		}
-		return new ArrayList<String>(orderedNames);
+		orderedNames.addAll(carriedGlobals.keySet());
+		orderedNames.addAll(basePersistentSeeds.keySet());
+		orderedNames.addAll(executionUserSeeds.keySet());
+		return new ArrayList<>(orderedNames);
 	}
 
 	/**
-	 * Restores retained global values into the runtime stack after the merged
-	 * layout has been installed.
+	 * Writes each entry from {@code globals} into the corresponding named slot in
+	 * the runtime stack.
 	 *
-	 * @param carriedGlobals retained user globals from the previous execution
+	 * @param globals map of variable name to value to apply
 	 */
-	private void restoreNamedGlobals(Map<String, Object> carriedGlobals) {
-		for (Map.Entry<String, Object> entry : carriedGlobals.entrySet()) {
-			runtimeStack.setGlobalVariable(entry.getKey(), entry.getValue());
-		}
-	}
-
-	/**
-	 * Applies baseline user globals when no retained value exists yet for the
-	 * same name.
-	 *
-	 * @param carriedGlobals retained user globals from the previous execution
-	 * @param basePersistentSeeds baseline user globals coming from the AVM settings
-	 */
-	private void seedMissingNamedGlobals(
-			Map<String, Object> carriedGlobals,
-			Map<String, Object> basePersistentSeeds) {
-		for (Map.Entry<String, Object> entry : basePersistentSeeds.entrySet()) {
-			if (!carriedGlobals.containsKey(entry.getKey())) {
-				runtimeStack.setGlobalVariable(entry.getKey(), entry.getValue());
-			}
-		}
-	}
-
-	/**
-	 * Applies per-execution user overrides on top of the merged runtime globals.
-	 *
-	 * @param executionUserSeeds per-call user overrides for this execution
-	 */
-	private void applyNamedGlobalOverrides(Map<String, Object> executionUserSeeds) {
-		for (Map.Entry<String, Object> entry : executionUserSeeds.entrySet()) {
+	private void applyGlobalsToStack(Map<String, Object> globals) {
+		for (Map.Entry<String, Object> entry : globals.entrySet()) {
 			runtimeStack.setGlobalVariable(entry.getKey(), entry.getValue());
 		}
 	}
@@ -933,12 +908,7 @@ public class AVM implements VariableManager, Closeable {
 	private boolean isPersistentEligibleGlobal(String name) {
 		return name != null
 				&& !JRT.isJrtManagedSpecialVariable(name)
-				&& !"ARGV".equals(name)
-				&& !"ARGC".equals(name)
-				&& !"ENVIRON".equals(name)
-				&& !"RSTART".equals(name)
-				&& !"RLENGTH".equals(name)
-				&& !"IGNORECASE".equals(name);
+				&& !NON_PERSISTENT_GLOBALS.contains(name);
 	}
 
 	/**
@@ -3290,6 +3260,13 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	private static final UninitializedObject BLANK = new UninitializedObject();
+
+	/**
+	 * Global names that must not participate in persistent memory even though they
+	 * are technically user-visible variables.
+	 */
+	private static final Set<String> NON_PERSISTENT_GLOBALS = new HashSet<>(
+			Arrays.asList("ARGV", "ARGC", "ENVIRON", "RSTART", "RLENGTH", "IGNORECASE"));
 
 	private static final class NameValueAssignment {
 		private final String name;

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -25,7 +25,6 @@ package io.jawk.backend;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -441,13 +440,12 @@ public class AVM implements VariableManager, Closeable {
 	 * persistent execution.
 	 * <p>
 	 * The returned snapshot is serializable and can later be fed back into
-	 * {@link #restorePersistentMemory(PersistentMemorySnapshot)} on this or another
-	 * AVM instance.
+	 * {@link #restorePersistentMemory(Map)} on this or another AVM instance.
 	 *
 	 * @return serializable snapshot of the persistent user-global bank
 	 */
-	public PersistentMemorySnapshot snapshotPersistentMemory() {
-		return new PersistentMemorySnapshot(collectPersistentGlobalValues());
+	public Map<String, Object> snapshotPersistentMemory() {
+		return new LinkedHashMap<String, Object>(collectPersistentGlobalValues());
 	}
 
 	/**
@@ -460,10 +458,10 @@ public class AVM implements VariableManager, Closeable {
 	 *
 	 * @param snapshot snapshot to restore
 	 */
-	public void restorePersistentMemory(PersistentMemorySnapshot snapshot) {
-		PersistentMemorySnapshot restoredSnapshot = Objects.requireNonNull(snapshot, "snapshot");
+	public void restorePersistentMemory(Map<String, Object> snapshot) {
+		Map<String, Object> restoredSnapshot = Objects.requireNonNull(snapshot, "snapshot");
 		Map<String, Object> restoredGlobals = new LinkedHashMap<String, Object>();
-		for (Map.Entry<String, Object> entry : restoredSnapshot.globalValues.entrySet()) {
+		for (Map.Entry<String, Object> entry : restoredSnapshot.entrySet()) {
 			if (isPersistentEligibleGlobal(entry.getKey())) {
 				restoredGlobals.put(entry.getKey(), entry.getValue());
 			}
@@ -3292,24 +3290,6 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	private static final UninitializedObject BLANK = new UninitializedObject();
-
-	/**
-	 * Serializable representation of the AVM's retained user-defined globals.
-	 * <p>
-	 * The snapshot intentionally excludes transient execution state, locals,
-	 * runtime-managed built-in variables, and open I/O resources.
-	 */
-	public static final class PersistentMemorySnapshot implements Serializable {
-
-		private static final long serialVersionUID = 1L;
-
-		/** Retained user-defined globals keyed by variable name. */
-		private final LinkedHashMap<String, Object> globalValues;
-
-		private PersistentMemorySnapshot(Map<String, Object> globalValues) {
-			this.globalValues = new LinkedHashMap<String, Object>(globalValues);
-		}
-	}
 
 	private static final class NameValueAssignment {
 		private final String name;

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -25,6 +25,7 @@ package io.jawk.backend;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -432,6 +433,46 @@ public class AVM implements VariableManager, Closeable {
 	 */
 	public void clearPersistentGlobals() {
 		runtimeStack.clearGlobals();
+		mergedGlobalLayoutActive = false;
+	}
+
+	/**
+	 * Captures the user-defined globals currently retained by this AVM for
+	 * persistent execution.
+	 * <p>
+	 * The returned snapshot is serializable and can later be fed back into
+	 * {@link #restorePersistentMemory(PersistentMemorySnapshot)} on this or another
+	 * AVM instance.
+	 *
+	 * @return serializable snapshot of the persistent user-global bank
+	 */
+	public PersistentMemorySnapshot snapshotPersistentMemory() {
+		return new PersistentMemorySnapshot(collectPersistentGlobalValues());
+	}
+
+	/**
+	 * Restores the user-defined globals retained by this AVM from a previously
+	 * captured persistent-memory snapshot.
+	 * <p>
+	 * Restoring a snapshot replaces the current retained global bank. The next
+	 * {@link #executePersistingGlobals(AwkProgram, InputSource, List, Map)} call
+	 * will merge these globals into the compiled layout of the incoming program.
+	 *
+	 * @param snapshot snapshot to restore
+	 */
+	public void restorePersistentMemory(PersistentMemorySnapshot snapshot) {
+		PersistentMemorySnapshot restoredSnapshot = Objects.requireNonNull(snapshot, "snapshot");
+		Map<String, Object> restoredGlobals = new LinkedHashMap<String, Object>();
+		for (Map.Entry<String, Object> entry : restoredSnapshot.globalValues.entrySet()) {
+			if (isPersistentEligibleGlobal(entry.getKey())) {
+				restoredGlobals.put(entry.getKey(), entry.getValue());
+			}
+		}
+		runtimeStack.clearGlobals();
+		if (!restoredGlobals.isEmpty()) {
+			runtimeStack.rebindGlobals(new ArrayList<String>(restoredGlobals.keySet()));
+			applyNamedGlobalOverrides(restoredGlobals);
+		}
 		mergedGlobalLayoutActive = false;
 	}
 
@@ -3251,6 +3292,24 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	private static final UninitializedObject BLANK = new UninitializedObject();
+
+	/**
+	 * Serializable representation of the AVM's retained user-defined globals.
+	 * <p>
+	 * The snapshot intentionally excludes transient execution state, locals,
+	 * runtime-managed built-in variables, and open I/O resources.
+	 */
+	public static final class PersistentMemorySnapshot implements Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		/** Retained user-defined globals keyed by variable name. */
+		private final LinkedHashMap<String, Object> globalValues;
+
+		private PersistentMemorySnapshot(Map<String, Object> globalValues) {
+			this.globalValues = new LinkedHashMap<String, Object>(globalValues);
+		}
+	}
 
 	private static final class NameValueAssignment {
 		private final String name;

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -25,6 +25,7 @@ package io.jawk.backend;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.ArrayDeque;
@@ -133,6 +134,7 @@ public class AVM implements VariableManager, Closeable {
 	private boolean inputSourceFilelistAssignmentsApplied;
 	private InputSource resolvedInputSource;
 	private AwkExpression installedEvalExpression;
+	private boolean mergedGlobalLayoutActive;
 
 	/**
 	 * Construct the interpreter.
@@ -335,9 +337,7 @@ public class AVM implements VariableManager, Closeable {
 		AwkProgram compiledProgram = Objects.requireNonNull(program, "program");
 		InputSource resolvedSource = Objects.requireNonNull(inputSource, "inputSource");
 		resetRuntimeState(runtimeArguments, variableOverrides);
-		globalVariableOffsets = compiledProgram.getGlobalVariableOffsetMap();
-		globalVariableArrays = compiledProgram.getGlobalVariableAarrayMap();
-		functionNames = compiledProgram.getFunctionNameSet();
+		installProgramMetadata(compiledProgram);
 
 		jrt.prepareForExecution(settings.getFieldSeparator(), settings.getDefaultRS());
 		if (!executionSpecialVariables.isEmpty()) {
@@ -345,6 +345,94 @@ public class AVM implements VariableManager, Closeable {
 		}
 		rebindResolvedInputSource(resolvedSource);
 		executeTuples(compiledProgram.top());
+	}
+
+	/**
+	 * Executes a compiled AWK program while persisting user-defined global
+	 * variables across repeated executions on this AVM instance.
+	 * <p>
+	 * Before the new program starts, this method imports any user-defined
+	 * globals currently materialized in the AVM and remaps them onto the
+	 * incoming program's compiled global slots.
+	 *
+	 * @param program compiled program to execute
+	 * @param inputSource input source providing records
+	 * @throws ExitException when the program terminates via {@code exit}
+	 * @throws IOException if execution fails
+	 */
+	public void executePersistingGlobals(AwkProgram program, InputSource inputSource)
+			throws ExitException,
+			IOException {
+		executePersistingGlobals(program, inputSource, Collections.<String>emptyList(), null);
+	}
+
+	/**
+	 * Executes a compiled AWK program while persisting user-defined global
+	 * variables across repeated executions on this AVM instance.
+	 * <p>
+	 * Before the new program starts, this method imports any user-defined
+	 * globals currently materialized in the AVM and remaps them onto the
+	 * incoming program's compiled global slots.
+	 *
+	 * @param program compiled program to execute
+	 * @param inputSource input source providing records
+	 * @param runtimeArguments name=value or filename entries from the command line
+	 * @throws ExitException when the program terminates via {@code exit}
+	 * @throws IOException if execution fails
+	 */
+	public void executePersistingGlobals(
+			AwkProgram program,
+			InputSource inputSource,
+			List<String> runtimeArguments)
+			throws ExitException,
+			IOException {
+		executePersistingGlobals(program, inputSource, runtimeArguments, null);
+	}
+
+	/**
+	 * Executes a compiled AWK program while persisting user-defined global
+	 * variables across repeated executions on this AVM instance.
+	 * <p>
+	 * Before the new program starts, this method imports any user-defined
+	 * globals currently materialized in the AVM and remaps them onto the
+	 * incoming program's compiled global slots.
+	 *
+	 * @param program compiled program to execute
+	 * @param inputSource input source providing records
+	 * @param runtimeArguments name=value or filename entries from the command line
+	 * @param variableOverrides additional variable assignments applied on top of
+	 *        the settings-level variables (may be {@code null})
+	 * @throws ExitException when the program terminates via {@code exit}
+	 * @throws IOException if execution fails
+	 */
+	public void executePersistingGlobals(
+			AwkProgram program,
+			InputSource inputSource,
+			List<String> runtimeArguments,
+			Map<String, Object> variableOverrides)
+			throws ExitException,
+			IOException {
+		AwkProgram compiledProgram = Objects.requireNonNull(program, "program");
+		InputSource resolvedSource = Objects.requireNonNull(inputSource, "inputSource");
+		mergeRuntimeState(runtimeArguments, variableOverrides, compiledProgram);
+
+		jrt.prepareForExecution(settings.getFieldSeparator(), settings.getDefaultRS());
+		if (!executionSpecialVariables.isEmpty()) {
+			jrt.applySpecialVariables(executionSpecialVariables);
+		}
+		rebindResolvedInputSource(resolvedSource);
+		executeTuples(compiledProgram.top());
+	}
+
+	/**
+	 * Clears the user-defined globals retained in the current runtime stack.
+	 * <p>
+	 * The next {@link #executePersistingGlobals(AwkProgram, InputSource, List, Map)}
+	 * call will therefore start from an empty persistent global bank.
+	 */
+	public void clearPersistentGlobals() {
+		runtimeStack.clearGlobals();
+		mergedGlobalLayoutActive = false;
 	}
 
 	private void initExtensions() {
@@ -459,6 +547,11 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	private void resetRuntimeState(List<String> runtimeArguments, Map<String, Object> variableOverrides) {
+		resetTransientRuntimeState(runtimeArguments, variableOverrides);
+		runtimeStack.clearGlobals();
+	}
+
+	private void resetTransientRuntimeState(List<String> runtimeArguments, Map<String, Object> variableOverrides) {
 		// Reset the AVM-owned state that must not leak across executions.
 		operandStack.clear();
 		environOffset = NULL_OFFSET;
@@ -475,10 +568,119 @@ public class AVM implements VariableManager, Closeable {
 		initializedEvalGlobalVariableOffsets = null;
 		initializedEvalGlobalVariableArrays = null;
 		installedEvalExpression = null;
-		runtimeStack.reset();
+		mergedGlobalLayoutActive = false;
+		runtimeStack.resetTransientState();
 		randomNumberGenerator.setSeed(1);
 		oldseed = 1;
 
+		prepareExecutionInputs(runtimeArguments, variableOverrides);
+	}
+
+	private void installExpressionMetadata(AwkExpression compiledExpression) {
+		if (installedEvalExpression == compiledExpression) {
+			return;
+		}
+		globalVariableOffsets = compiledExpression.getGlobalVariableOffsetMap();
+		globalVariableArrays = compiledExpression.getGlobalVariableAarrayMap();
+		functionNames = compiledExpression.getFunctionNameSet();
+		installedEvalExpression = compiledExpression;
+	}
+
+	private void installProgramMetadata(AwkProgram compiledProgram) {
+		globalVariableOffsets = compiledProgram.getGlobalVariableOffsetMap();
+		globalVariableArrays = compiledProgram.getGlobalVariableAarrayMap();
+		functionNames = compiledProgram.getFunctionNameSet();
+	}
+
+	private void rebindResolvedInputSource(InputSource resolvedSource) {
+		InputSource previousResolvedSource = resolvedInputSource;
+		if (previousResolvedSource != null && previousResolvedSource != resolvedSource) {
+			closeInputSource(previousResolvedSource);
+		}
+		resolvedInputSource = resolvedSource;
+	}
+
+	private boolean hasCompatibleEvalGlobalLayout(long numGlobals) {
+		Object[] globals = runtimeStack.getNumGlobals();
+		return globals != null
+				&& globals.length == numGlobals
+				&& Objects.equals(initializedEvalGlobalVariableOffsets, globalVariableOffsets)
+				&& Objects.equals(initializedEvalGlobalVariableArrays, globalVariableArrays);
+	}
+
+	/**
+	 * Resets transient execution state, installs the new program metadata, and
+	 * merges the previously retained user globals into the new compiled global
+	 * layout.
+	 *
+	 * @param runtimeArguments name=value or filename entries for this execution
+	 * @param variableOverrides per-call variable overrides for this execution
+	 * @param compiledProgram program whose global layout should become active
+	 */
+	private void mergeRuntimeState(
+			List<String> runtimeArguments,
+			Map<String, Object> variableOverrides,
+			AwkProgram compiledProgram) {
+		Map<String, Object> carriedGlobals = collectPersistentGlobalValues();
+		resetTransientRuntimeState(runtimeArguments, variableOverrides);
+		installProgramMetadata(compiledProgram);
+
+		Map<String, Object> basePersistentSeeds = collectBasePersistentGlobalSeeds();
+		Map<String, Object> executionUserSeeds = collectExecutionUserGlobalSeeds(runtimeArguments, variableOverrides);
+		List<String> mergedGlobalNamesByOffset = buildMergedGlobalNamesByOffset(
+				carriedGlobals,
+				basePersistentSeeds,
+				executionUserSeeds);
+
+		runtimeStack.rebindGlobals(mergedGlobalNamesByOffset);
+		restoreNamedGlobals(carriedGlobals);
+		seedMissingNamedGlobals(carriedGlobals, basePersistentSeeds);
+		applyNamedGlobalOverrides(executionUserSeeds);
+		mergedGlobalLayoutActive = true;
+	}
+
+	/**
+	 * Returns whether the current runtime stack already contains a merged global
+	 * layout for the compiled program about to execute.
+	 * <p>
+	 * Persistent execution may append previously retained globals after the
+	 * compiled globals of the incoming program. The tuple stream only dereferences
+	 * the prefix defined by {@code SET_NUM_GLOBALS}, so appended globals are valid
+	 * as long as the compiled prefix still matches name-for-name and offset-for-offset.
+	 *
+	 * @param numGlobals number of globals compiled into the active program
+	 * @return {@code true} when the merged layout is compatible with the active
+	 *         program
+	 */
+	private boolean hasCompatiblePersistentGlobalLayout(long numGlobals) {
+		Object[] globals = runtimeStack.getNumGlobals();
+		if (!mergedGlobalLayoutActive
+				|| globals == null
+				|| globalVariableOffsets == null
+				|| globals.length < numGlobals) {
+			return false;
+		}
+		for (Map.Entry<String, Integer> entry : globalVariableOffsets.entrySet()) {
+			int offset = entry.getValue().intValue();
+			if (offset < 0 || offset >= globals.length || !entry.getKey().equals(runtimeStack.getGlobalName(offset))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Prepares the per-execution runtime arguments and variable overrides.
+	 * <p>
+	 * Base settings-level variables remain the default source. Per-call overrides
+	 * are layered on top without mutating the base snapshot held by this AVM.
+	 *
+	 * @param runtimeArguments name=value or filename entries for this execution
+	 * @param variableOverrides per-call variable overrides for this execution
+	 */
+	private void prepareExecutionInputs(
+			List<String> runtimeArguments,
+			Map<String, Object> variableOverrides) {
 		this.arguments = runtimeArguments != null ? new ArrayList<>(runtimeArguments) : Collections.<String>emptyList();
 
 		if (variableOverrides == null || variableOverrides.isEmpty()) {
@@ -498,30 +700,221 @@ public class AVM implements VariableManager, Closeable {
 		}
 	}
 
-	private void installExpressionMetadata(AwkExpression compiledExpression) {
-		if (installedEvalExpression == compiledExpression) {
-			return;
+	/**
+	 * Collects the current user-defined globals retained in the runtime stack.
+	 *
+	 * @return retained user globals keyed by name, in current runtime order
+	 */
+	private Map<String, Object> collectPersistentGlobalValues() {
+		Map<String, Object> retainedGlobals = new LinkedHashMap<String, Object>();
+		for (Map.Entry<String, Object> entry : runtimeStack.snapshotGlobalVariables().entrySet()) {
+			if (isPersistentEligibleGlobal(entry.getKey())) {
+				retainedGlobals.put(entry.getKey(), entry.getValue());
+			}
 		}
-		globalVariableOffsets = compiledExpression.getGlobalVariableOffsetMap();
-		globalVariableArrays = compiledExpression.getGlobalVariableAarrayMap();
-		functionNames = compiledExpression.getFunctionNameSet();
-		installedEvalExpression = compiledExpression;
+		return retainedGlobals;
 	}
 
-	private void rebindResolvedInputSource(InputSource resolvedSource) {
-		InputSource previousResolvedSource = resolvedInputSource;
-		if (previousResolvedSource != null && previousResolvedSource != resolvedSource) {
-			closeInputSource(previousResolvedSource);
+	/**
+	 * Collects the AVM-wide baseline variables that should seed persistent
+	 * globals when no retained value exists yet for the same name.
+	 *
+	 * @return baseline user globals keyed by name
+	 */
+	private Map<String, Object> collectBasePersistentGlobalSeeds() {
+		Map<String, Object> basePersistentSeeds = new LinkedHashMap<String, Object>();
+		for (Map.Entry<String, Object> entry : baseInitialVariables.entrySet()) {
+			String name = entry.getKey();
+			if (isPersistentEligibleGlobal(name)) {
+				validateSeededGlobal(name, entry.getValue());
+				basePersistentSeeds.put(name, entry.getValue());
+			}
 		}
-		resolvedInputSource = resolvedSource;
+		return basePersistentSeeds;
 	}
 
-	private boolean hasCompatibleEvalGlobalLayout(long numGlobals) {
-		Object[] globals = runtimeStack.getNumGlobals();
-		return globals != null
-				&& globals.length == numGlobals
-				&& Objects.equals(initializedEvalGlobalVariableOffsets, globalVariableOffsets)
-				&& Objects.equals(initializedEvalGlobalVariableArrays, globalVariableArrays);
+	/**
+	 * Collects the user-defined variables that should override the retained
+	 * global bank for the current persistent execution.
+	 * <p>
+	 * Only user globals are included here. JRT-managed special variables still
+	 * flow through the normal execution setup.
+	 *
+	 * @param runtimeArguments name=value or filename entries for this execution
+	 * @param variableOverrides per-call variable overrides for this execution
+	 * @return insertion-ordered overriding seed values keyed by variable name
+	 */
+	private Map<String, Object> collectExecutionUserGlobalSeeds(
+			List<String> runtimeArguments,
+			Map<String, Object> variableOverrides) {
+		Map<String, Object> executionUserSeeds = new LinkedHashMap<String, Object>();
+		if (variableOverrides != null) {
+			for (Map.Entry<String, Object> entry : variableOverrides.entrySet()) {
+				String name = entry.getKey();
+				if (isPersistentEligibleGlobal(name)) {
+					validateSeededGlobal(name, entry.getValue());
+					executionUserSeeds.put(name, entry.getValue());
+				}
+			}
+		}
+		for (String argument : runtimeArguments != null ? runtimeArguments : Collections.<String>emptyList()) {
+			if (argument.indexOf('=') <= 0) {
+				continue;
+			}
+			NameValueAssignment assignment = parseNameValueAssignment(argument);
+			if (isPersistentEligibleGlobal(assignment.name)) {
+				validateSeededGlobal(assignment.name, assignment.value);
+				executionUserSeeds.put(assignment.name, assignment.value);
+			}
+		}
+		return executionUserSeeds;
+	}
+
+	/**
+	 * Builds the slot order for the next persistent execution.
+	 * <p>
+	 * The compiled globals are always installed first in their compiled offset
+	 * order. Retained globals and seeded user globals that are not compiled by
+	 * the incoming program are appended afterwards so future runs can still reuse
+	 * them without changing the current program's compiled offsets.
+	 *
+	 * @param carriedGlobals retained user globals from the previous execution
+	 * @param basePersistentSeeds baseline user globals coming from the AVM settings
+	 * @param executionUserSeeds per-call user overrides for this execution
+	 * @return merged slot-to-name layout for the next persistent run
+	 */
+	private List<String> buildMergedGlobalNamesByOffset(
+			Map<String, Object> carriedGlobals,
+			Map<String, Object> basePersistentSeeds,
+			Map<String, Object> executionUserSeeds) {
+		LinkedHashSet<String> orderedNames = new LinkedHashSet<String>();
+		List<Map.Entry<String, Integer>> compiledGlobals = new ArrayList<Map.Entry<String, Integer>>(
+				globalVariableOffsets.entrySet());
+		Collections.sort(compiledGlobals, (left, right) -> left.getValue().compareTo(right.getValue()));
+		for (Map.Entry<String, Integer> entry : compiledGlobals) {
+			orderedNames.add(entry.getKey());
+		}
+		for (String name : carriedGlobals.keySet()) {
+			orderedNames.add(name);
+		}
+		for (String name : basePersistentSeeds.keySet()) {
+			orderedNames.add(name);
+		}
+		for (String name : executionUserSeeds.keySet()) {
+			orderedNames.add(name);
+		}
+		return new ArrayList<String>(orderedNames);
+	}
+
+	/**
+	 * Restores retained global values into the runtime stack after the merged
+	 * layout has been installed.
+	 *
+	 * @param carriedGlobals retained user globals from the previous execution
+	 */
+	private void restoreNamedGlobals(Map<String, Object> carriedGlobals) {
+		for (Map.Entry<String, Object> entry : carriedGlobals.entrySet()) {
+			runtimeStack.setGlobalVariable(entry.getKey(), entry.getValue());
+		}
+	}
+
+	/**
+	 * Applies baseline user globals when no retained value exists yet for the
+	 * same name.
+	 *
+	 * @param carriedGlobals retained user globals from the previous execution
+	 * @param basePersistentSeeds baseline user globals coming from the AVM settings
+	 */
+	private void seedMissingNamedGlobals(
+			Map<String, Object> carriedGlobals,
+			Map<String, Object> basePersistentSeeds) {
+		for (Map.Entry<String, Object> entry : basePersistentSeeds.entrySet()) {
+			if (!carriedGlobals.containsKey(entry.getKey())) {
+				runtimeStack.setGlobalVariable(entry.getKey(), entry.getValue());
+			}
+		}
+	}
+
+	/**
+	 * Applies per-execution user overrides on top of the merged runtime globals.
+	 *
+	 * @param executionUserSeeds per-call user overrides for this execution
+	 */
+	private void applyNamedGlobalOverrides(Map<String, Object> executionUserSeeds) {
+		for (Map.Entry<String, Object> entry : executionUserSeeds.entrySet()) {
+			runtimeStack.setGlobalVariable(entry.getKey(), entry.getValue());
+		}
+	}
+
+	/**
+	 * Returns whether the given global name should participate in persistent
+	 * memory.
+	 *
+	 * @param name global variable name
+	 * @return {@code true} when the variable should persist across runs
+	 */
+	private boolean isPersistentEligibleGlobal(String name) {
+		return name != null
+				&& !JRT.isJrtManagedSpecialVariable(name)
+				&& !"ARGV".equals(name)
+				&& !"ARGC".equals(name)
+				&& !"ENVIRON".equals(name)
+				&& !"RSTART".equals(name)
+				&& !"RLENGTH".equals(name)
+				&& !"IGNORECASE".equals(name);
+	}
+
+	/**
+	 * Validates that a seeded global value is compatible with the compiled
+	 * metadata of the current program.
+	 *
+	 * @param name variable name to validate
+	 * @param value proposed seeded value
+	 */
+	private void validateSeededGlobal(String name, Object value) {
+		if (functionNames.contains(name)) {
+			throw new IllegalArgumentException("Cannot assign a scalar to a function name (" + name + ").");
+		}
+		Boolean arrayObj = globalVariableArrays.get(name);
+		if (Boolean.TRUE.equals(arrayObj) && !(value instanceof Map)) {
+			throw new IllegalArgumentException("Cannot assign a scalar to a non-scalar variable (" + name + ").");
+		}
+	}
+
+	/**
+	 * Parses a runtime {@code name=value} assignment.
+	 *
+	 * @param nameValue raw assignment text
+	 * @return parsed assignment
+	 */
+	private NameValueAssignment parseNameValueAssignment(String nameValue) {
+		int eqIdx = nameValue.indexOf('=');
+		if (eqIdx == 0) {
+			throw new IllegalArgumentException(
+					"Must have a non-blank variable name in a name=value variable assignment argument.");
+		}
+		String name = nameValue.substring(0, eqIdx);
+		String value = nameValue.substring(eqIdx + 1);
+		return new NameValueAssignment(name, coerceVariableAssignmentValue(value));
+	}
+
+	/**
+	 * Coerces a runtime assignment value using the same scalar rules as the
+	 * existing command-line handling: integer first, then double, then string.
+	 *
+	 * @param value raw text to coerce
+	 * @return coerced scalar value
+	 */
+	private Object coerceVariableAssignmentValue(String value) {
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException nfe) {
+			try {
+				return Double.parseDouble(value);
+			} catch (NumberFormatException nfe2) {
+				return value;
+			}
+		}
 	}
 
 	/**
@@ -1943,8 +2336,13 @@ public class AVM implements VariableManager, Closeable {
 				case SET_NUM_GLOBALS: {
 					// arg[0] = # of globals
 					Object[] globals = runtimeStack.getNumGlobals();
-					if (globals == null) {
-						runtimeStack.setNumGlobals(position.intArg(0));
+					if (mergedGlobalLayoutActive) {
+						if (!hasCompatiblePersistentGlobalLayout(position.intArg(0))) {
+							throw new IllegalStateException(
+									"AVM globals are already initialized for an incompatible persistent layout.");
+						}
+					} else if (globals == null) {
+						runtimeStack.setNumGlobals(position.intArg(0), globalVariableOffsets);
 						initializedEvalGlobalVariableOffsets = globalVariableOffsets;
 						initializedEvalGlobalVariableArrays = globalVariableArrays;
 
@@ -2618,24 +3016,9 @@ public class AVM implements VariableManager, Closeable {
 	 */
 	@SuppressWarnings("unused")
 	private void setFilelistVariable(String nameValue) {
-		int eqIdx = nameValue.indexOf('=');
-		// variable name should be non-blank
-		if (eqIdx == 0) {
-			throw new IllegalArgumentException(
-					"Must have a non-blank variable name in a name=value variable assignment argument.");
-		}
-		String name = nameValue.substring(0, eqIdx);
-		String value = nameValue.substring(eqIdx + 1);
-		Object obj;
-		try {
-			obj = Integer.parseInt(value);
-		} catch (NumberFormatException nfe) {
-			try {
-				obj = Double.parseDouble(value);
-			} catch (NumberFormatException nfe2) {
-				obj = value;
-			}
-		}
+		NameValueAssignment assignment = parseNameValueAssignment(nameValue);
+		String name = assignment.name;
+		Object obj = assignment.value;
 
 		// make sure we're not receiving funcname=value assignments
 		if (functionNames.contains(name)) {
@@ -2651,8 +3034,9 @@ public class AVM implements VariableManager, Closeable {
 			} else {
 				runtimeStack.setFilelistVariable(offsetObj.intValue(), obj);
 			}
+		} else if (runtimeStack.hasGlobalVariable(name)) {
+			runtimeStack.setGlobalVariable(name, obj);
 		}
-		// otherwise, do nothing
 	}
 
 	/** {@inheritDoc} */
@@ -2682,6 +3066,8 @@ public class AVM implements VariableManager, Closeable {
 			} else {
 				runtimeStack.setFilelistVariable(offsetObj.intValue(), obj);
 			}
+		} else if (runtimeStack.hasGlobalVariable(name)) {
+			runtimeStack.setGlobalVariable(name, obj);
 		}
 	}
 
@@ -2846,6 +3232,16 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	private static final UninitializedObject BLANK = new UninitializedObject();
+
+	private static final class NameValueAssignment {
+		private final String name;
+		private final Object value;
+
+		private NameValueAssignment(String name, Object value) {
+			this.name = name;
+			this.value = value;
+		}
+	}
 
 	private static final class SingleRecordInputSource implements InputSource {
 

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -670,9 +670,7 @@ public class AVM implements VariableManager, Closeable {
 
 		runtimeStack.rebindGlobals(mergedGlobalNamesByOffset);
 		applyGlobalsToStack(carriedGlobals);
-		Map<String, Object> missingSeeds = new LinkedHashMap<>(basePersistentSeeds);
-		missingSeeds.keySet().removeAll(carriedGlobals.keySet());
-		applyGlobalsToStack(missingSeeds);
+		applyGlobalsToStack(basePersistentSeeds);
 		applyGlobalsToStack(executionUserSeeds);
 		mergedGlobalLayoutActive = true;
 	}
@@ -803,8 +801,8 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	/**
-	 * Collects the AVM-wide baseline variables that should seed persistent
-	 * globals when no retained value exists yet for the same name.
+	 * Collects the AVM-wide baseline variables that should be reapplied before
+	 * each persistent execution.
 	 *
 	 * @return baseline user globals keyed by name
 	 */

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -662,7 +662,7 @@ public class AVM implements VariableManager, Closeable {
 		installProgramMetadata(compiledProgram);
 
 		Map<String, Object> basePersistentSeeds = collectBasePersistentGlobalSeeds();
-		Map<String, Object> executionUserSeeds = collectExecutionUserGlobalSeeds(runtimeArguments, variableOverrides);
+		Map<String, Object> executionUserSeeds = collectExecutionUserGlobalSeeds(variableOverrides);
 		List<String> mergedGlobalNamesByOffset = buildMergedGlobalNamesByOffset(
 				carriedGlobals,
 				basePersistentSeeds,
@@ -827,13 +827,10 @@ public class AVM implements VariableManager, Closeable {
 	 * Only user globals are included here. JRT-managed special variables still
 	 * flow through the normal execution setup.
 	 *
-	 * @param runtimeArguments name=value or filename entries for this execution
 	 * @param variableOverrides per-call variable overrides for this execution
 	 * @return insertion-ordered overriding seed values keyed by variable name
 	 */
-	private Map<String, Object> collectExecutionUserGlobalSeeds(
-			List<String> runtimeArguments,
-			Map<String, Object> variableOverrides) {
+	private Map<String, Object> collectExecutionUserGlobalSeeds(Map<String, Object> variableOverrides) {
 		Map<String, Object> executionUserSeeds = new LinkedHashMap<>();
 		if (variableOverrides != null) {
 			for (Map.Entry<String, Object> entry : variableOverrides.entrySet()) {
@@ -842,16 +839,6 @@ public class AVM implements VariableManager, Closeable {
 					validateSeededGlobal(name, entry.getValue());
 					executionUserSeeds.put(name, entry.getValue());
 				}
-			}
-		}
-		for (String argument : runtimeArguments != null ? runtimeArguments : Collections.<String>emptyList()) {
-			if (argument.indexOf('=') <= 0) {
-				continue;
-			}
-			NameValueAssignment assignment = parseNameValueAssignment(argument);
-			if (isPersistentEligibleGlobal(assignment.name)) {
-				validateSeededGlobal(assignment.name, assignment.value);
-				executionUserSeeds.put(assignment.name, assignment.value);
 			}
 		}
 		return executionUserSeeds;

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -670,6 +670,44 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	/**
+	 * Applies execution-level initial variables to stack-managed globals.
+	 * <p>
+	 * Plain {@link #execute(AwkProgram, InputSource, List, Map)} calls apply all
+	 * compatible globals here. Persistent executions only reapply non-persistent
+	 * globals so carried user globals are not overwritten unless they were
+	 * explicitly supplied for the current run.
+	 *
+	 * @param skipPersistentEligibleGlobals whether persistent user globals should
+	 *        be skipped by this application pass
+	 */
+	private void applyExecutionInitialVariablesToGlobalSlots(boolean skipPersistentEligibleGlobals) {
+		for (Map.Entry<String, Object> entry : executionInitialVariables.entrySet()) {
+			String key = entry.getKey();
+			if (skipPersistentEligibleGlobals && isPersistentEligibleGlobal(key)) {
+				continue;
+			}
+			if (functionNames.contains(key)) {
+				throw new IllegalArgumentException("Cannot assign a scalar to a function name (" + key + ").");
+			}
+			Integer offsetObj = globalVariableOffsets.get(key);
+			Boolean arrayObj = globalVariableArrays.get(key);
+			if (offsetObj != null) {
+				Object obj = entry.getValue();
+				if (arrayObj.booleanValue()) {
+					if (obj instanceof Map) {
+						runtimeStack.setFilelistVariable(offsetObj.intValue(), obj);
+					} else {
+						throw new IllegalArgumentException(
+								"Cannot assign a scalar to a non-scalar variable (" + key + ").");
+					}
+				} else {
+					runtimeStack.setFilelistVariable(offsetObj.intValue(), obj);
+				}
+			}
+		}
+	}
+
+	/**
 	 * Prepares the per-execution runtime arguments and variable overrides.
 	 * <p>
 	 * Base settings-level variables remain the default source. Per-call overrides
@@ -2341,6 +2379,7 @@ public class AVM implements VariableManager, Closeable {
 							throw new IllegalStateException(
 									"AVM globals are already initialized for an incompatible persistent layout.");
 						}
+						applyExecutionInitialVariablesToGlobalSlots(true);
 					} else if (globals == null) {
 						runtimeStack.setNumGlobals(position.intArg(0), globalVariableOffsets);
 						initializedEvalGlobalVariableOffsets = globalVariableOffsets;
@@ -2350,27 +2389,7 @@ public class AVM implements VariableManager, Closeable {
 						// we can allocate the initial variables
 
 						// assign -v variables and per-call overrides prepared for this execution
-						for (Map.Entry<String, Object> entry : executionInitialVariables.entrySet()) {
-							String key = entry.getKey();
-							if (functionNames.contains(key)) {
-								throw new IllegalArgumentException("Cannot assign a scalar to a function name (" + key + ").");
-							}
-							Integer offsetObj = globalVariableOffsets.get(key);
-							Boolean arrayObj = globalVariableArrays.get(key);
-							if (offsetObj != null) {
-								Object obj = entry.getValue();
-								if (arrayObj.booleanValue()) {
-									if (obj instanceof Map) {
-										runtimeStack.setFilelistVariable(offsetObj.intValue(), obj);
-									} else {
-										throw new IllegalArgumentException(
-												"Cannot assign a scalar to a non-scalar variable (" + key + ").");
-									}
-								} else {
-									runtimeStack.setFilelistVariable(offsetObj.intValue(), obj);
-								}
-							}
-						}
+						applyExecutionInitialVariablesToGlobalSlots(false);
 					} else if (!hasCompatibleEvalGlobalLayout(position.intArg(0))) {
 						throw new IllegalStateException(
 								"AVM globals are already initialized for a different eval layout. Call prepareForEval(...) first.");

--- a/src/main/java/io/jawk/backend/RuntimeStack.java
+++ b/src/main/java/io/jawk/backend/RuntimeStack.java
@@ -23,8 +23,13 @@ package io.jawk.backend;
  */
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import io.jawk.intermediate.UninitializedObject;
 
 /**
@@ -36,6 +41,8 @@ class RuntimeStack {
 	private static final Object[] NULL_LOCALS_SENTINEL = new Object[0];
 
 	private Object[] globals = null;
+	private List<String> globalNamesByOffset = Collections.emptyList();
+	private Map<String, Integer> globalOffsetsByName = Collections.emptyMap();
 	private Object[] locals = null;
 	private Deque<Object[]> localsStack = new ArrayDeque<Object[]>();
 	private Deque<Integer> returnIndexes = new ArrayDeque<Integer>();
@@ -43,6 +50,7 @@ class RuntimeStack {
 	@SuppressWarnings("unused")
 	public void dump() {
 		System.out.println("globals = " + Arrays.toString(globals));
+		System.out.println("globalNamesByOffset = " + globalNamesByOffset);
 		System.out.println("locals = " + Arrays.toString(locals));
 		System.out.println("localsStack = " + localsStack);
 		System.out.println("returnIndexes = " + returnIndexes);
@@ -53,7 +61,17 @@ class RuntimeStack {
 	}
 
 	void reset() {
+		clearGlobals();
+		resetTransientState();
+	}
+
+	void clearGlobals() {
 		globals = null;
+		globalNamesByOffset = Collections.emptyList();
+		globalOffsetsByName = Collections.emptyMap();
+	}
+
+	void resetTransientState() {
 		locals = null;
 		localsStack.clear();
 		returnIndexes.clear();
@@ -61,11 +79,12 @@ class RuntimeStack {
 	}
 
 	/** Must be one of the first methods executed. */
-	void setNumGlobals(long l) {
+	void setNumGlobals(long l, Map<String, Integer> offsetsByName) {
 		globals = new Object[(int) l];
 		for (int i = 0; i < l; i++) {
 			globals[i] = null;
 		}
+		setGlobalLayoutMetadata((int) l, offsetsByName);
 		// must accept multiple executions
 		// expandFrameIfNecessary(num_globals);
 	}
@@ -83,6 +102,48 @@ class RuntimeStack {
 	 * globals = new_frame;
 	 * }
 	 */
+
+	void rebindGlobals(List<String> namesByOffset) {
+		globals = new Object[namesByOffset.size()];
+		for (int i = 0; i < globals.length; i++) {
+			globals[i] = null;
+		}
+		setGlobalLayoutMetadata(namesByOffset);
+	}
+
+	Map<String, Object> snapshotGlobalVariables() {
+		Map<String, Object> snapshot = new LinkedHashMap<String, Object>();
+		if (globals == null) {
+			return snapshot;
+		}
+		for (int i = 0; i < globals.length && i < globalNamesByOffset.size(); i++) {
+			String name = globalNamesByOffset.get(i);
+			if (name != null) {
+				snapshot.put(name, globals[i]);
+			}
+		}
+		return snapshot;
+	}
+
+	boolean hasGlobalVariable(String name) {
+		return globalOffsetsByName.containsKey(name);
+	}
+
+	Object getGlobalVariable(String name) {
+		Integer offset = globalOffsetsByName.get(name);
+		return offset == null ? null : globals[offset.intValue()];
+	}
+
+	void setGlobalVariable(String name, Object value) {
+		Integer offset = globalOffsetsByName.get(name);
+		if (offset != null) {
+			globals[offset.intValue()] = value;
+		}
+	}
+
+	String getGlobalName(int offset) {
+		return offset >= 0 && offset < globalNamesByOffset.size() ? globalNamesByOffset.get(offset) : null;
+	}
 
 	Object getVariable(long offset, boolean isGlobal) {
 		if (isGlobal) {
@@ -151,5 +212,30 @@ class RuntimeStack {
 		}
 		returnValue = null;
 		return retval;
+	}
+
+	private void setGlobalLayoutMetadata(int numGlobals, Map<String, Integer> offsetsByName) {
+		List<String> namesByOffset = new ArrayList<String>(Collections.nCopies(numGlobals, (String) null));
+		if (offsetsByName != null) {
+			for (Map.Entry<String, Integer> entry : offsetsByName.entrySet()) {
+				int offset = entry.getValue().intValue();
+				if (offset >= 0 && offset < numGlobals) {
+					namesByOffset.set(offset, entry.getKey());
+				}
+			}
+		}
+		setGlobalLayoutMetadata(namesByOffset);
+	}
+
+	private void setGlobalLayoutMetadata(List<String> namesByOffset) {
+		globalNamesByOffset = new ArrayList<String>(namesByOffset);
+		Map<String, Integer> offsetsByName = new LinkedHashMap<String, Integer>();
+		for (int i = 0; i < namesByOffset.size(); i++) {
+			String name = namesByOffset.get(i);
+			if (name != null) {
+				offsetsByName.put(name, Integer.valueOf(i));
+			}
+		}
+		globalOffsetsByName = offsetsByName;
 	}
 }

--- a/src/main/java/io/jawk/intermediate/UninitializedObject.java
+++ b/src/main/java/io/jawk/intermediate/UninitializedObject.java
@@ -29,7 +29,9 @@ package io.jawk.intermediate;
  *
  * @author Danny Daglas
  */
-public class UninitializedObject {
+public class UninitializedObject implements java.io.Serializable {
+
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * <p>

--- a/src/site/markdown/cli-reference.md
+++ b/src/site/markdown/cli-reference.md
@@ -32,6 +32,7 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 >   - `script` is the inline AWK program used when you do not pass `-f` or `-L`.
 >   - `-f <filename>` reads a script from a file. You can repeat `-f` to combine multiple script sources.
 >   - `-L <filename>` loads previously serialized `AwkTuples` instead of compiling source now.
+>   - `--persist <filename>` loads retained user-defined globals from a serialized state file before execution and writes them back after the run finishes.
 >   - `-K <filename>` compiles the current script sources to a tuples file and exits without executing the script.
 >
 > - Input and `ARGV`
@@ -49,6 +50,7 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 >   - `--locale <locale>` sets the locale through `Locale.forLanguageTag(...)`.
 >   - `-t` keeps associative array keys sorted.
 >   - `--posix` enforces POSIX-oriented compile-time behavior such as disabling gawk-style nested arrays.
+>   - `JAWK_PERSISTENT_MEMORY` can also point at the persistent-memory file when you do not want to pass `--persist` explicitly. `--persist` wins when both are present.
 >
 > - Extensions and sandbox
 >
@@ -76,6 +78,7 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 - `--posix` is rejected together with `-L`, because loading precompiled tuples bypasses source compilation entirely.
 - `-L` lets you skip source compilation, but the loaded tuples must still be compatible with the current runtime.
 - `-f` and `-L` are distinct paths: source files compile now, tuple files load now.
+- `--persist` and `JAWK_PERSISTENT_MEMORY` affect only real execution. Non-executing modes such as `-K`, `--dump-syntax`, and `--dump-intermediate` ignore persistent memory.
 
 ## Tuple Serialization Compatibility
 
@@ -85,6 +88,8 @@ Jawk tuples are reusable, but they should be treated as internal artifacts tied 
 - `-L` reads those tuples back
 - version mismatches can cause tuple loading to fail
 - the safe fix is to recompile the tuples with the current Jawk version
+
+Persistent memory files use the same Java serialization machinery. They are therefore version-sensitive as well and should be discarded when Jawk reports an incompatibility.
 
 ## See Also
 

--- a/src/site/markdown/java-advanced.md
+++ b/src/site/markdown/java-advanced.md
@@ -67,6 +67,8 @@ try (AVM avm = awk.createAvm()) {
 
 `executePersistingGlobals(...)` first imports the user-defined globals currently materialized in that `AVM`, then remaps them onto the next program's compiled global slots. The persistent memory lives only for that `AVM` instance. Built-in runtime variables such as `NR`, `NF`, `FS`, and `RS` still reset between runs.
 
+If you need to carry that retained global bank into another `AVM` instance, serialize `avm.snapshotPersistentMemory()` and later restore it with `restorePersistentMemory(...)` before the next `executePersistingGlobals(...)` call.
+
 ## Why Stateful Eval Is Powerful and Dangerous
 
 Raw repeated eval against one runtime is intentionally stateful:

--- a/src/site/markdown/java-advanced.md
+++ b/src/site/markdown/java-advanced.md
@@ -52,6 +52,21 @@ try (AVM avm = awk.createAvm()) {
 
 Each `execute(...)` resets the AWK execution state before the program starts again, but it still reuses the same interpreter instance and runtime infrastructure.
 
+When you want user-defined globals to survive into a later program run on the same runtime, use `executePersistingGlobals(...)` for the run where you want the remapping to happen:
+
+```java
+Awk awk = new Awk();
+AwkProgram first = awk.compile("BEGIN { total = 5 }");
+AwkProgram second = awk.compile("BEGIN { print total }");
+
+try (AVM avm = awk.createAvm()) {
+    avm.execute(first, firstSource);
+    avm.executePersistingGlobals(second, secondSource);
+}
+```
+
+`executePersistingGlobals(...)` first imports the user-defined globals currently materialized in that `AVM`, then remaps them onto the next program's compiled global slots. The persistent memory lives only for that `AVM` instance. Built-in runtime variables such as `NR`, `NF`, `FS`, and `RS` still reset between runs.
+
 ## Why Stateful Eval Is Powerful and Dangerous
 
 Raw repeated eval against one runtime is intentionally stateful:

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1573,7 +1573,7 @@ public class AwkTest {
 		AwkProgram assign = AWK.compile("BEGIN { arr[\"x\"] = 9; total = 7 }");
 		AwkProgram read = AWK.compile("BEGIN { print total, arr[\"x\"] }");
 
-		AVM.PersistentMemorySnapshot snapshot;
+		Map<String, Object> snapshot;
 		try (AVM writer = AWK.createAvm()) {
 			assertEquals("", executePersistent(writer, assign));
 			ByteArrayOutputStream bytes = new ByteArrayOutputStream();
@@ -1581,7 +1581,9 @@ public class AwkTest {
 				oos.writeObject(writer.snapshotPersistentMemory());
 			}
 			try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
-				snapshot = (AVM.PersistentMemorySnapshot) ois.readObject();
+				@SuppressWarnings("unchecked")
+				Map<String, Object> restoredSnapshot = (Map<String, Object>) ois.readObject();
+				snapshot = restoredSnapshot;
 			}
 		}
 

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1622,28 +1622,30 @@ public class AwkTest {
 		return out.toString();
 	}
 
+	private static final InputSource EMPTY_INPUT_SOURCE = new InputSource() {
+		@Override
+		public boolean nextRecord() {
+			return false;
+		}
+
+		@Override
+		public String getRecordText() {
+			return null;
+		}
+
+		@Override
+		public List<String> getFields() {
+			return null;
+		}
+
+		@Override
+		public boolean isFromFilenameList() {
+			return false;
+		}
+	};
+
 	private static InputSource emptyInputSource() {
-		return new InputSource() {
-			@Override
-			public boolean nextRecord() {
-				return false;
-			}
-
-			@Override
-			public String getRecordText() {
-				return null;
-			}
-
-			@Override
-			public List<String> getFields() {
-				return null;
-			}
-
-			@Override
-			public boolean isFromFilenameList() {
-				return false;
-			}
-		};
+		return EMPTY_INPUT_SOURCE;
 	}
 
 	private static final class ThrowingAfterFirstRecordInputSource implements InputSource {

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1505,14 +1505,26 @@ public class AwkTest {
 	public void executePersistingGlobalsDoesNotPersistBuiltInsAndKeepsArraysOnlyForGlobals() throws Exception {
 		AwkProgram writeBuiltIn = AWK.compile("BEGIN { NR = 99; print NR }");
 		AwkProgram readBuiltIn = AWK.compile("BEGIN { print NR }");
+		AwkProgram readIgnoreCase = AWK.compile("BEGIN { print IGNORECASE + 0, match(\"Abc\", \"abc\") }");
 		AwkProgram seedArrayAndLocal = AWK
 				.compile(
 						"function seed(tmp) { tmp = 7; arr[\"x\"] = 9 } BEGIN { seed() }");
 		AwkProgram readArrayAndLocal = AWK.compile("BEGIN { print arr[\"x\"]; print tmp }");
+		Map<String, Object> ignoreCaseOverride = new LinkedHashMap<String, Object>();
+		ignoreCaseOverride.put("IGNORECASE", Long.valueOf(1L));
 
 		try (AVM avm = AWK.createAvm()) {
 			assertEquals("99\n", executePersistent(avm, writeBuiltIn));
 			assertEquals("0\n", executePersistent(avm, readBuiltIn));
+			assertEquals(
+					"1 1\n",
+					executePersistent(
+							avm,
+							readIgnoreCase,
+							Collections.<String>emptyList(),
+							ignoreCaseOverride,
+							emptyInputSource()));
+			assertEquals("0 0\n", executePersistent(avm, readIgnoreCase));
 			assertEquals("", executePersistent(avm, seedArrayAndLocal));
 			assertEquals("9\n\n", executePersistent(avm, readArrayAndLocal));
 		}

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1522,6 +1522,21 @@ public class AwkTest {
 	}
 
 	@Test
+	public void executePersistingGlobalsReappliesBaselineVariablesBeforeBegin() throws Exception {
+		AwkSettings settings = new AwkSettings();
+		settings.putVariable("x", Long.valueOf(5L));
+		Awk configuredAwk = new Awk(settings);
+		AwkProgram mutate = configuredAwk.compile("BEGIN { print x; x++ }");
+		AwkProgram read = configuredAwk.compile("BEGIN { print x }");
+
+		try (AVM avm = configuredAwk.createAvm()) {
+			assertEquals("5\n", executePersistent(avm, mutate));
+			assertEquals("5\n", executePersistent(avm, read));
+			assertEquals("5\n", executePersistent(avm, mutate));
+		}
+	}
+
+	@Test
 	public void executePersistingGlobalsDoesNotPersistBuiltInsAndKeepsArraysOnlyForGlobals() throws Exception {
 		AwkProgram writeBuiltIn = AWK.compile("BEGIN { NR = 99; print NR }");
 		AwkProgram readBuiltIn = AWK.compile("BEGIN { print NR }");

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -45,6 +45,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
@@ -1435,6 +1436,204 @@ public class AwkTest {
 				.script("BEGIN { print ARGV[0] }")
 				.expect("\n")
 				.runAndAssert();
+	}
+
+	@Test
+	public void executePersistingGlobalsSharesUserGlobalsAcrossPrograms() throws Exception {
+		Awk awk = new Awk();
+		AwkProgram first = awk.compile("BEGIN { A = 1; B = 2; C = 3; print A, B, C }");
+		AwkProgram second = awk.compile("BEGIN { D = C + 1; C = C + 10; print C, D }");
+		AwkProgram third = awk.compile("BEGIN { print A, B, C, D }");
+
+		try (AVM avm = awk.createAvm()) {
+			assertEquals("1 2 3\n", executePersistent(avm, first));
+			assertEquals("13 4\n", executePersistent(avm, second));
+			assertEquals("1 2 13 4\n", executePersistent(avm, third));
+		}
+	}
+
+	@Test
+	public void executePersistingGlobalsRetainsGlobalsAcrossRepeatedRunsOfSameProgram() throws Exception {
+		AwkProgram program = AWK.compile("BEGIN { count++; print count }");
+
+		try (AVM avm = AWK.createAvm()) {
+			assertEquals("1\n", executePersistent(avm, program));
+			assertEquals("2\n", executePersistent(avm, program));
+		}
+	}
+
+	@Test
+	public void existingExecuteDoesNotPersistGlobals() throws Exception {
+		AwkProgram assign = AWK.compile("BEGIN { A = 1 }");
+		AwkProgram read = AWK.compile("BEGIN { print A }");
+
+		try (AVM avm = AWK.createAvm()) {
+			assertEquals("", executeNormally(avm, assign));
+			assertEquals("\n", executeNormally(avm, read));
+		}
+	}
+
+	@Test
+	public void executePersistingGlobalsImportsGlobalsFromPreviousExecute() throws Exception {
+		AwkProgram first = AWK.compile("BEGIN { A = 1; B = 2; C = 3 }");
+		AwkProgram second = AWK.compile("BEGIN { D = C + 1; C = C + 10 }");
+		AwkProgram third = AWK.compile("BEGIN { print A, B, C, D }");
+
+		try (AVM avm = AWK.createAvm()) {
+			assertEquals("", executeNormally(avm, first));
+			assertEquals("", executePersistent(avm, second));
+			assertEquals("1 2 13 4\n", executePersistent(avm, third));
+		}
+	}
+
+	@Test
+	public void executePersistingGlobalsPersistsSeededCompiledAndUncompiledUserGlobals() throws Exception {
+		AwkProgram seedNothing = AWK.compile("BEGIN { }");
+		AwkProgram readValues = AWK.compile("BEGIN { print x, y }");
+		Map<String, Object> overrides = new LinkedHashMap<String, Object>();
+		overrides.put("x", Long.valueOf(4L));
+
+		try (AVM avm = AWK.createAvm()) {
+			assertEquals(
+					"",
+					executePersistent(avm, seedNothing, Collections.singletonList("y=5"), overrides, emptyInputSource()));
+			assertEquals("4 5\n", executePersistent(avm, readValues));
+		}
+	}
+
+	@Test
+	public void executePersistingGlobalsDoesNotPersistBuiltInsAndKeepsArraysOnlyForGlobals() throws Exception {
+		AwkProgram writeBuiltIn = AWK.compile("BEGIN { NR = 99; print NR }");
+		AwkProgram readBuiltIn = AWK.compile("BEGIN { print NR }");
+		AwkProgram seedArrayAndLocal = AWK
+				.compile(
+						"function seed(tmp) { tmp = 7; arr[\"x\"] = 9 } BEGIN { seed() }");
+		AwkProgram readArrayAndLocal = AWK.compile("BEGIN { print arr[\"x\"]; print tmp }");
+
+		try (AVM avm = AWK.createAvm()) {
+			assertEquals("99\n", executePersistent(avm, writeBuiltIn));
+			assertEquals("0\n", executePersistent(avm, readBuiltIn));
+			assertEquals("", executePersistent(avm, seedArrayAndLocal));
+			assertEquals("9\n\n", executePersistent(avm, readArrayAndLocal));
+		}
+	}
+
+	@Test
+	public void executePersistingGlobalsPersistsMutationsBeforeExitAndIoFailure() throws Exception {
+		AwkProgram exitProgram = AWK.compile("BEGIN { A = 3; exit 7 }");
+		AwkProgram increment = AWK.compile("{ A++ }");
+		AwkProgram readA = AWK.compile("BEGIN { print A }");
+
+		try (AVM avm = AWK.createAvm()) {
+			avm.setAwkSink(new AppendableAwkSink(new StringBuilder(), java.util.Locale.US));
+			ExitException exit = assertThrows(
+					ExitException.class,
+					() -> avm.executePersistingGlobals(exitProgram, emptyInputSource()));
+			assertEquals(7, exit.getCode());
+			assertEquals("3\n", executePersistent(avm, readA));
+
+			avm.clearPersistentGlobals();
+			avm.setAwkSink(new AppendableAwkSink(new StringBuilder(), java.util.Locale.US));
+			IOException io = assertThrows(
+					IOException.class,
+					() -> avm.executePersistingGlobals(increment, new ThrowingAfterFirstRecordInputSource()));
+			assertEquals("boom", io.getMessage());
+			assertEquals("1\n", executePersistent(avm, readA));
+		}
+	}
+
+	@Test
+	public void clearPersistentGlobalsRemovesOnlyPersistentUserGlobals() throws Exception {
+		AwkProgram assign = AWK.compile("BEGIN { A = 1 }");
+		AwkProgram read = AWK.compile("BEGIN { print A }");
+
+		try (AVM avm = AWK.createAvm()) {
+			assertEquals("", executePersistent(avm, assign));
+			avm.clearPersistentGlobals();
+			assertEquals("\n", executePersistent(avm, read));
+			assertEquals("\n", executeNormally(avm, read));
+		}
+	}
+
+	private static String executePersistent(AVM avm, AwkProgram program) throws Exception {
+		return executePersistent(
+				avm,
+				program,
+				Collections.<String>emptyList(),
+				Collections.<String, Object>emptyMap(),
+				emptyInputSource());
+	}
+
+	private static String executePersistent(
+			AVM avm,
+			AwkProgram program,
+			List<String> arguments,
+			Map<String, Object> variableOverrides,
+			InputSource inputSource)
+			throws Exception {
+		StringBuilder out = new StringBuilder();
+		avm.setAwkSink(new AppendableAwkSink(out, java.util.Locale.US));
+		avm.executePersistingGlobals(program, inputSource, arguments, variableOverrides);
+		return out.toString();
+	}
+
+	private static String executeNormally(AVM avm, AwkProgram program) throws Exception {
+		StringBuilder out = new StringBuilder();
+		avm.setAwkSink(new AppendableAwkSink(out, java.util.Locale.US));
+		avm.execute(program, emptyInputSource(), Collections.<String>emptyList(), null);
+		return out.toString();
+	}
+
+	private static InputSource emptyInputSource() {
+		return new InputSource() {
+			@Override
+			public boolean nextRecord() {
+				return false;
+			}
+
+			@Override
+			public String getRecordText() {
+				return null;
+			}
+
+			@Override
+			public List<String> getFields() {
+				return null;
+			}
+
+			@Override
+			public boolean isFromFilenameList() {
+				return false;
+			}
+		};
+	}
+
+	private static final class ThrowingAfterFirstRecordInputSource implements InputSource {
+		private boolean firstRecordAvailable = true;
+
+		@Override
+		public boolean nextRecord() throws IOException {
+			if (firstRecordAvailable) {
+				firstRecordAvailable = false;
+				return true;
+			}
+			throw new IOException("boom");
+		}
+
+		@Override
+		public String getRecordText() {
+			return "row";
+		}
+
+		@Override
+		public List<String> getFields() {
+			return null;
+		}
+
+		@Override
+		public boolean isFromFilenameList() {
+			return false;
+		}
 	}
 
 	private static final class StructuredOutputSink extends AwkSink {

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
@@ -1564,6 +1565,29 @@ public class AwkTest {
 			avm.clearPersistentGlobals();
 			assertEquals("\n", executePersistent(avm, read));
 			assertEquals("\n", executeNormally(avm, read));
+		}
+	}
+
+	@Test
+	public void persistentMemorySnapshotRestoresGlobalsIntoAnotherAvm() throws Exception {
+		AwkProgram assign = AWK.compile("BEGIN { arr[\"x\"] = 9; total = 7 }");
+		AwkProgram read = AWK.compile("BEGIN { print total, arr[\"x\"] }");
+
+		AVM.PersistentMemorySnapshot snapshot;
+		try (AVM writer = AWK.createAvm()) {
+			assertEquals("", executePersistent(writer, assign));
+			ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+			try (ObjectOutputStream oos = new ObjectOutputStream(bytes)) {
+				oos.writeObject(writer.snapshotPersistentMemory());
+			}
+			try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+				snapshot = (AVM.PersistentMemorySnapshot) ois.readObject();
+			}
+		}
+
+		try (AVM reader = AWK.createAvm()) {
+			reader.restorePersistentMemory(snapshot);
+			assertEquals("7 9\n", executePersistent(reader, read));
 		}
 	}
 

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1493,12 +1493,31 @@ public class AwkTest {
 		AwkProgram readValues = AWK.compile("BEGIN { print x, y }");
 		Map<String, Object> overrides = new LinkedHashMap<String, Object>();
 		overrides.put("x", Long.valueOf(4L));
+		overrides.put("y", Long.valueOf(5L));
 
 		try (AVM avm = AWK.createAvm()) {
 			assertEquals(
 					"",
-					executePersistent(avm, seedNothing, Collections.singletonList("y=5"), overrides, emptyInputSource()));
+					executePersistent(avm, seedNothing, Collections.<String>emptyList(), overrides, emptyInputSource()));
 			assertEquals("4 5\n", executePersistent(avm, readValues));
+		}
+	}
+
+	@Test
+	public void executePersistingGlobalsDefersRuntimeArgumentAssignmentsUntilInputTraversal() throws Exception {
+		AwkProgram seedFromRuntimeArguments = AWK.compile("BEGIN { print x } { x = x } END { print x }");
+		AwkProgram readValue = AWK.compile("BEGIN { print x }");
+
+		try (AVM avm = AWK.createAvm()) {
+			assertEquals(
+					"\n1\n",
+					executePersistent(
+							avm,
+							seedFromRuntimeArguments,
+							Collections.singletonList("x=1"),
+							Collections.<String, Object>emptyMap(),
+							new SingleRecordInputSource("record")));
+			assertEquals("1\n", executePersistent(avm, readValue));
 		}
 	}
 
@@ -1668,6 +1687,39 @@ public class AwkTest {
 		@Override
 		public List<String> getFields() {
 			return null;
+		}
+
+		@Override
+		public boolean isFromFilenameList() {
+			return false;
+		}
+	}
+
+	private static final class SingleRecordInputSource implements InputSource {
+		private final String record;
+		private boolean consumed;
+
+		private SingleRecordInputSource(String record) {
+			this.record = record;
+		}
+
+		@Override
+		public boolean nextRecord() {
+			if (consumed) {
+				return false;
+			}
+			consumed = true;
+			return true;
+		}
+
+		@Override
+		public String getRecordText() {
+			return consumed ? record : null;
+		}
+
+		@Override
+		public List<String> getFields() {
+			return consumed ? Collections.singletonList(record) : null;
 		}
 
 		@Override

--- a/src/test/java/io/jawk/AwkTestSupport.java
+++ b/src/test/java/io/jawk/AwkTestSupport.java
@@ -555,7 +555,7 @@ public final class AwkTestSupport {
 		 * @param value environment variable value
 		 * @return this builder for method chaining
 		 */
-		public CliTestBuilder environmentVariable(String name, String value) {
+		public CliTestBuilder env(String name, String value) {
 			environment.put(name, value);
 			return this;
 		}
@@ -568,7 +568,7 @@ public final class AwkTestSupport {
 		 * @param values environment variables to expose
 		 * @return this builder for method chaining
 		 */
-		public CliTestBuilder environmentVariables(Map<String, String> values) {
+		public CliTestBuilder env(Map<String, String> values) {
 			if (values != null) {
 				environment.putAll(values);
 			}

--- a/src/test/java/io/jawk/AwkTestSupport.java
+++ b/src/test/java/io/jawk/AwkTestSupport.java
@@ -516,6 +516,7 @@ public final class AwkTestSupport {
 	public static final class CliTestBuilder extends BaseTestBuilder<CliTestBuilder> {
 		private final List<String> argumentSpecs = new ArrayList<>();
 		private final Map<String, Object> assignments = new LinkedHashMap<>();
+		private final Map<String, String> environment = new LinkedHashMap<>();
 
 		private CliTestBuilder(String description) {
 			super(description);
@@ -546,6 +547,34 @@ public final class AwkTestSupport {
 			return this;
 		}
 
+		/**
+		 * Adds one environment variable that should be visible to the CLI during
+		 * execution. Placeholder tokens in the value are resolved at runtime.
+		 *
+		 * @param name environment variable name
+		 * @param value environment variable value
+		 * @return this builder for method chaining
+		 */
+		public CliTestBuilder environmentVariable(String name, String value) {
+			environment.put(name, value);
+			return this;
+		}
+
+		/**
+		 * Adds several environment variables that should be visible to the CLI
+		 * during execution. Placeholder tokens in the values are resolved at
+		 * runtime.
+		 *
+		 * @param values environment variables to expose
+		 * @return this builder for method chaining
+		 */
+		public CliTestBuilder environmentVariables(Map<String, String> values) {
+			if (values != null) {
+				environment.putAll(values);
+			}
+			return this;
+		}
+
 		@Override
 		protected CliTestCase buildTestCase(
 				TestLayout layout,
@@ -555,7 +584,15 @@ public final class AwkTestSupport {
 			if (useTempDir && !assignments.containsKey("TEMPDIR")) {
 				assignments.put("TEMPDIR", SHARED_TEMP_DIR.toString());
 			}
-			return new CliTestCase(layout, files, operands, placeholders, requiresPosix, argumentSpecs, assignments);
+			return new CliTestCase(
+					layout,
+					files,
+					operands,
+					placeholders,
+					requiresPosix,
+					argumentSpecs,
+					assignments,
+					environment);
 		}
 	}
 
@@ -1039,6 +1076,7 @@ public final class AwkTestSupport {
 	private static final class CliTestCase extends BaseTestCase {
 		private final List<String> argumentSpecs;
 		private final Map<String, Object> assignments;
+		private final Map<String, String> environment;
 
 		CliTestCase(
 				TestLayout layout,
@@ -1047,10 +1085,12 @@ public final class AwkTestSupport {
 				List<String> pathPlaceholders,
 				boolean requiresPosix,
 				List<String> argumentSpecs,
-				Map<String, Object> assignments) {
+				Map<String, Object> assignments,
+				Map<String, String> environment) {
 			super(layout, fileContents, operandSpecs, pathPlaceholders, requiresPosix);
 			this.argumentSpecs = new ArrayList<>(argumentSpecs);
 			this.assignments = new LinkedHashMap<>(assignments);
+			this.environment = new LinkedHashMap<>(environment);
 		}
 
 		@Override
@@ -1061,10 +1101,15 @@ public final class AwkTestSupport {
 					new ByteArrayInputStream(new byte[0]);
 			ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
 			ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
+			Map<String, String> resolvedEnvironment = new LinkedHashMap<String, String>();
+			for (Map.Entry<String, String> entry : environment.entrySet()) {
+				resolvedEnvironment.put(entry.getKey(), env.resolve(entry.getValue()));
+			}
 			Cli cli = new Cli(
 					in,
 					new PrintStream(outBytes, true, StandardCharsets.UTF_8.name()),
-					new PrintStream(errBytes, true, StandardCharsets.UTF_8.name()));
+					new PrintStream(errBytes, true, StandardCharsets.UTF_8.name()),
+					resolvedEnvironment);
 
 			List<String> args = new ArrayList<>();
 			for (Map.Entry<String, Object> entry : assignments.entrySet()) {

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -29,6 +29,9 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.ObjectOutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -118,6 +121,16 @@ public class CliOptionTest {
 	}
 
 	@Test
+	public void persistOptionWithoutFilenameReportsMissingArgument() {
+		Cli cli = new Cli();
+		IllegalArgumentException ex = assertThrows(
+				IllegalArgumentException.class,
+				() -> cli.parse(new String[]
+				{ "--persist" }));
+		assertTrue(ex.getMessage().contains("Need additional argument for --persist"));
+	}
+
+	@Test
 	public void helpOutputDoesNotAdvertiseUnsupportedOutputOption() throws Exception {
 		AwkTestSupport.TestResult result = AwkTestSupport
 				.cliTest("CLI help omits unsupported -o option")
@@ -142,6 +155,103 @@ public class CliOptionTest {
 				{ "-L", bad.getAbsolutePath(), "{ print }" }));
 		assertTrue(ex.getMessage().contains("does not contain a valid precompiled AwkProgram"));
 		assertTrue(ex.getCause() instanceof ClassCastException);
+	}
+
+	@Test
+	public void persistOptionPersistsUserGlobalsAcrossCliRuns() throws Exception {
+		File memory = new File(tempFolder.getRoot(), "memory.bin");
+
+		AwkTestSupport
+				.cliTest("CLI persist first run")
+				.argument("--persist", memory.getAbsolutePath())
+				.script("BEGIN { print ++i }")
+				.expect("1\n")
+				.expectExit(0)
+				.runAndAssert();
+		assertTrue(memory.isFile());
+		AwkTestSupport
+				.cliTest("CLI persist second run")
+				.argument("--persist", memory.getAbsolutePath())
+				.script("BEGIN { print ++i }")
+				.expect("2\n")
+				.expectExit(0)
+				.runAndAssert();
+	}
+
+	@Test
+	public void persistentMemoryEnvironmentVariablePersistsUserGlobalsAcrossCliRuns() throws Exception {
+		File memory = new File(tempFolder.getRoot(), "env-memory.bin");
+		Map<String, String> environment = Collections
+				.singletonMap(
+						"JAWK_PERSISTENT_MEMORY",
+						memory.getAbsolutePath());
+
+		AwkTestSupport
+				.cliTest("CLI env persist first run")
+				.environmentVariables(environment)
+				.script("BEGIN { print ++i }")
+				.expect("1\n")
+				.expectExit(0)
+				.runAndAssert();
+		assertTrue(memory.isFile());
+		AwkTestSupport
+				.cliTest("CLI env persist second run")
+				.environmentVariables(environment)
+				.script("BEGIN { print ++i }")
+				.expect("2\n")
+				.expectExit(0)
+				.runAndAssert();
+	}
+
+	@Test
+	public void persistOptionOverridesPersistentMemoryEnvironmentVariable() throws Exception {
+		File optionMemory = new File(tempFolder.getRoot(), "option-memory.bin");
+		File envMemory = new File(tempFolder.getRoot(), "env-memory.bin");
+		Map<String, String> environment = new HashMap<String, String>();
+		environment.put("JAWK_PERSISTENT_MEMORY", envMemory.getAbsolutePath());
+
+		AwkTestSupport
+				.cliTest("CLI persist option first run")
+				.environmentVariables(environment)
+				.argument("--persist", optionMemory.getAbsolutePath())
+				.script("BEGIN { print ++i }")
+				.expect("1\n")
+				.expectExit(0)
+				.runAndAssert();
+		AwkTestSupport
+				.cliTest("CLI env-only persist run")
+				.environmentVariables(environment)
+				.script("BEGIN { print ++i }")
+				.expect("1\n")
+				.expectExit(0)
+				.runAndAssert();
+		AwkTestSupport
+				.cliTest("CLI persist option second run")
+				.environmentVariables(environment)
+				.argument("--persist", optionMemory.getAbsolutePath())
+				.script("BEGIN { print ++i }")
+				.expect("2\n")
+				.expectExit(0)
+				.runAndAssert();
+	}
+
+	@Test
+	public void persistOptionWithWrongSerializedTypeThrowsFriendlyError() throws Exception {
+		File bad = tempFolder.newFile("wrong-persistent-type.ser");
+		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(bad))) {
+			oos.writeObject("not persistent memory");
+		}
+
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.cliTest("CLI persist rejects wrong serialized type")
+				.argument("--persist", bad.getAbsolutePath())
+				.script("BEGIN { print 1 }")
+				.expectThrow(IllegalArgumentException.class)
+				.run();
+
+		result.assertExpected();
+		assertTrue(result.thrownException().getMessage().contains("does not contain valid Jawk persistent memory"));
+		assertTrue(result.thrownException().getCause() instanceof ClassCastException);
 	}
 
 	private static void writeProgram(File target, String script) throws Exception {

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -22,13 +22,20 @@ package io.jawk;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -274,9 +281,47 @@ public class CliOptionTest {
 		assertTrue(result.thrownException().getCause() instanceof ClassCastException);
 	}
 
+	@Test
+	public void persistOptionFlushesOutputBeforeSaveFailure() throws Exception {
+		File blockingParent = tempFolder.newFile("not-a-directory");
+		File memory = new File(blockingParent, "memory.bin");
+		FlushTrackingOutputStream output = new FlushTrackingOutputStream();
+		Cli cli = new Cli(
+				new ByteArrayInputStream(new byte[0]),
+				new PrintStream(output, false, StandardCharsets.UTF_8.name()),
+				new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8.name()),
+				Collections.<String, String>emptyMap());
+		cli.parse(new String[] { "--persist", memory.getAbsolutePath(), "BEGIN { print \"ok\" }" });
+
+		IOException ex = assertThrows(IOException.class, () -> cli.run());
+
+		assertTrue(ex.getMessage().contains("Failed to create directory"));
+		assertEquals("ok\n", output.flushedText());
+	}
+
 	private static void writeProgram(File target, String script) throws Exception {
 		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(target))) {
 			oos.writeObject(new Awk().compile(script));
+		}
+	}
+
+	private static final class FlushTrackingOutputStream extends OutputStream {
+		private final ByteArrayOutputStream pending = new ByteArrayOutputStream();
+		private final ByteArrayOutputStream flushed = new ByteArrayOutputStream();
+
+		@Override
+		public void write(int b) {
+			pending.write(b);
+		}
+
+		@Override
+		public void flush() throws IOException {
+			pending.writeTo(flushed);
+			pending.reset();
+		}
+
+		private String flushedText() {
+			return new String(flushed.toByteArray(), StandardCharsets.UTF_8);
 		}
 	}
 }

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -179,6 +179,26 @@ public class CliOptionTest {
 	}
 
 	@Test
+	public void persistOptionPersistsAssociativeArraysAcrossCliRuns() throws Exception {
+		File memory = new File(tempFolder.getRoot(), "array-memory.bin");
+
+		AwkTestSupport
+				.cliTest("CLI persist array first run")
+				.argument("--persist", memory.getAbsolutePath())
+				.script("BEGIN { arr[\"x\"] = 9 }")
+				.expect("")
+				.expectExit(0)
+				.runAndAssert();
+		AwkTestSupport
+				.cliTest("CLI persist array second run")
+				.argument("--persist", memory.getAbsolutePath())
+				.script("BEGIN { print arr[\"x\"] }")
+				.expect("9\n")
+				.expectExit(0)
+				.runAndAssert();
+	}
+
+	@Test
 	public void persistentMemoryEnvironmentVariablePersistsUserGlobalsAcrossCliRuns() throws Exception {
 		File memory = new File(tempFolder.getRoot(), "env-memory.bin");
 		Map<String, String> environment = Collections
@@ -251,7 +271,9 @@ public class CliOptionTest {
 
 		result.assertExpected();
 		assertTrue(result.thrownException().getMessage().contains("does not contain valid Jawk persistent memory"));
-		assertTrue(result.thrownException().getCause() instanceof ClassCastException);
+		assertTrue(
+				result.thrownException().getCause() instanceof ClassCastException
+						|| result.thrownException().getCause() instanceof java.io.InvalidClassException);
 	}
 
 	private static void writeProgram(File target, String script) throws Exception {

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -188,7 +188,7 @@ public class CliOptionTest {
 
 		AwkTestSupport
 				.cliTest("CLI env persist first run")
-				.environmentVariables(environment)
+				.env(environment)
 				.script("BEGIN { print ++i }")
 				.expect("1\n")
 				.expectExit(0)
@@ -196,7 +196,7 @@ public class CliOptionTest {
 		assertTrue(memory.isFile());
 		AwkTestSupport
 				.cliTest("CLI env persist second run")
-				.environmentVariables(environment)
+				.env(environment)
 				.script("BEGIN { print ++i }")
 				.expect("2\n")
 				.expectExit(0)
@@ -212,7 +212,7 @@ public class CliOptionTest {
 
 		AwkTestSupport
 				.cliTest("CLI persist option first run")
-				.environmentVariables(environment)
+				.env(environment)
 				.argument("--persist", optionMemory.getAbsolutePath())
 				.script("BEGIN { print ++i }")
 				.expect("1\n")
@@ -220,14 +220,14 @@ public class CliOptionTest {
 				.runAndAssert();
 		AwkTestSupport
 				.cliTest("CLI env-only persist run")
-				.environmentVariables(environment)
+				.env(environment)
 				.script("BEGIN { print ++i }")
 				.expect("1\n")
 				.expectExit(0)
 				.runAndAssert();
 		AwkTestSupport
 				.cliTest("CLI persist option second run")
-				.environmentVariables(environment)
+				.env(environment)
 				.argument("--persist", optionMemory.getAbsolutePath())
 				.script("BEGIN { print ++i }")
 				.expect("2\n")

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -207,7 +207,7 @@ public class CliOptionTest {
 	public void persistOptionOverridesPersistentMemoryEnvironmentVariable() throws Exception {
 		File optionMemory = new File(tempFolder.getRoot(), "option-memory.bin");
 		File envMemory = new File(tempFolder.getRoot(), "env-memory.bin");
-		Map<String, String> environment = new HashMap<String, String>();
+		Map<String, String> environment = new HashMap<>();
 		environment.put("JAWK_PERSISTENT_MEMORY", envMemory.getAbsolutePath());
 
 		AwkTestSupport

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -271,9 +271,7 @@ public class CliOptionTest {
 
 		result.assertExpected();
 		assertTrue(result.thrownException().getMessage().contains("does not contain valid Jawk persistent memory"));
-		assertTrue(
-				result.thrownException().getCause() instanceof ClassCastException
-						|| result.thrownException().getCause() instanceof java.io.InvalidClassException);
+		assertTrue(result.thrownException().getCause() instanceof ClassCastException);
 	}
 
 	private static void writeProgram(File target, String script) throws Exception {


### PR DESCRIPTION
## Summary
- Move persistent global layout 
This pull request introduces support for persistent user-defined global variables in the Jawk CLI, allowing globals to be saved to and restored from a file between runs. This is achieved via a new `--persist` command-line option or the `JAWK_PERSISTENT_MEMORY` environment variable. The implementation includes serialization of the global state, updates to the CLI and documentation, and new integration tests to verify behavior.

Persistent memory support:

* Added support for persistent user-defined globals via a new `--persist <filename>` CLI option and the `JAWK_PERSISTENT_MEMORY` environment variable. The CLI now loads globals from the specified file before execution and saves them after execution. The `--persist` flag takes precedence over the environment variable. (`src/main/java/io/jawk/Cli.java`, `src/site/markdown/cli-reference.md`) [[1]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2R239-R242) [[2]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2L403-R544) [[3]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2R561) [[4]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2R580-R586) [[5]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2R62) [[6]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2R93-R99) [[7]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2L102-R129) [[8]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2R79) [[9]](diffhunk://#diff-72178d0b65ee5b6cefaafd642b262194c23477296430947b39abbde7c7458b3fR35) [[10]](diffhunk://#diff-72178d0b65ee5b6cefaafd642b262194c23477296430947b39abbde7c7458b3fR53) [[11]](diffhunk://#diff-72178d0b65ee5b6cefaafd642b262194c23477296430947b39abbde7c7458b3fR81)

Runtime and serialization changes:

* Enhanced `RuntimeStack` to support snapshotting and restoring global variables by name, including methods for serialization and layout rebinding. Made `UninitializedObject` serializable to support persistence. (`src/main/java/io/jawk/backend/RuntimeStack.java`, `src/main/java/io/jawk/intermediate/UninitializedObject.java`) [[1]](diffhunk://#diff-036b98776efa9dd1fc3da1ba71b8200a1b8008e34ca2dd248606626589576ccbR26-R32) [[2]](diffhunk://#diff-036b98776efa9dd1fc3da1ba71b8200a1b8008e34ca2dd248606626589576ccbR44-R53) [[3]](diffhunk://#diff-036b98776efa9dd1fc3da1ba71b8200a1b8008e34ca2dd248606626589576ccbR64-R87) [[4]](diffhunk://#diff-036b98776efa9dd1fc3da1ba71b8200a1b8008e34ca2dd248606626589576ccbR106-R147) [[5]](diffhunk://#diff-036b98776efa9dd1fc3da1ba71b8200a1b8008e34ca2dd248606626589576ccbR216-R240) [[6]](diffhunk://#diff-3d4269b39640bc6486f8534f8ed86f2d902e74ffaebaba30ac644f5fafca87dcL32-R34)

Testing:

* Added and updated integration tests to verify persistent memory behavior, including round-trip tests for saving and restoring globals between runs. (`src/it/java/io/jawk/gawk/GawkOptionalFeatureIT.java`) [[1]](diffhunk://#diff-932495cecaa4760deda734d38cd62a34eabdf4777b1d6741cb1ab859e04e8a14R25-R29) [[2]](diffhunk://#diff-932495cecaa4760deda734d38cd62a34eabdf4777b1d6741cb1ab859e04e8a14L600-R626)

Documentation and usage:

* Updated CLI usage messages and documentation to describe the new persistent memory options and their precedence. (`src/main/java/io/jawk/Cli.java`, `src/site/markdown/cli-reference.md`) [[1]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2R561) [[2]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2R580-R586) [[3]](diffhunk://#diff-72178d0b65ee5b6cefaafd642b262194c23477296430947b39abbde7c7458b3fR35) [[4]](diffhunk://#diff-72178d0b65ee5b6cefaafd642b262194c23477296430947b39abbde7c7458b3fR53) [[5]](diffhunk://#diff-72178d0b65ee5b6cefaafd642b262194c23477296430947b39abbde7c7458b3fR81)

Minor improvements:

* Minor code cleanups and improvements to error messages and formatting. (`src/main/java/io/jawk/Cli.java`) [[1]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2L496) [[2]](diffhunk://#diff-8290957bc79eb24409f5bb685dbd228182345f77a4e5c750126874cbde0212c2L506-R663)and name tracking into `RuntimeStack`
- Keep `execute(...)` unchanged while `executePersistingGlobals(...)` now merges and rebinds globals through the runtime stack
- Update docs and tests for cross-run persistence, cleanup, and import-from-previous-execute behavior

## Testing
- Added and updated unit tests for sequential persistent runs, imported globals from a prior plain run, built-in exclusion, arrays, locals, and termination persistence
- Ran `mvn formatter:format`, `mvn clean test`, `mvn verify`, and `mvn verify site` successfully