### PR TITLE
Fixed compatibility dashboards generation in documentation site

### DIFF
--- a/src/site/markdown/compatibility.md.vm
+++ b/src/site/markdown/compatibility.md.vm
@@ -12,15 +12,13 @@ Jawk is checked during `mvn verify` against 3 upstream compatibility families:
 [GNU Awk](https://www.gnu.org/software/gawk/). This page summarizes what currently passes, fails, errors, or remains intentionally skipped.
 
 #set($summaryPath = "${project.build.directory}/generated-site/compatibility-summary.xml")
-#set($summaryFile = $files.getFile($summaryPath))
+#set($summary = $xml.fetch("file:///${summaryPath}"))
 
 POSIX
 -----
 
 Specification-focused coverage transcribed from the [POSIX awk utility requirements](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/awk.html).
 
-#if($summaryFile.exists())
-#set($summary = $xml.read($summaryPath))
 #set($posixSummary = $summary.find("/compatibility-summary/suite[@id='posix']").getFirst())
 #set($bwkSummary = $summary.find("/compatibility-summary/suite[@id='bwk']").getFirst())
 #set($gawkSummary = $summary.find("/compatibility-summary/suite[@id='gawk']").getFirst())
@@ -172,9 +170,6 @@ GNU Awk (gawk)
 </div>
 <p class="compat-suite-footer"><a href="failsafe.html#io-jawk-gawk">Open the Failsafe report</a> for per-test details, stack traces, and grouped results.</p>
 
-#else
-Compatibility data is unavailable in this build. Run `mvn verify site` to generate the compatibility reports and this dashboard.
-#end
 #else
 Compatibility data is unavailable in this build. Run `mvn verify site` to generate the compatibility reports and this dashboard.
 #end

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -29,13 +29,11 @@ application and integrate with your Java code:
 >   ```
 
 #set($summaryPath = "${project.build.directory}/generated-site/compatibility-summary.xml")
-#set($summaryFile = $files.getFile($summaryPath))
+#set($summary = $xml.fetch("file:///${summaryPath}"))
 
 Compatibility and Compliance
 ----------------------------
 
-#if($summaryFile.exists())
-#set($summary = $xml.read($summaryPath))
 #set($posixSummary = $summary.find("/compatibility-summary/suite[@id='posix']").getFirst())
 #set($bwkSummary = $summary.find("/compatibility-summary/suite[@id='bwk']").getFirst())
 #set($gawkSummary = $summary.find("/compatibility-summary/suite[@id='gawk']").getFirst())
@@ -100,9 +98,6 @@ Compatibility and Compliance
 
 The above scores are calculated from the latest compatibility tests during `mvn verify site`. See the full [compatibility dashboard](compatibility.html) for per-suite maps and the [Failsafe report](failsafe.html) for detailed test results.
 
-#else
-Compatibility summary is unavailable in this build. Run `mvn verify site` to generate the compatibility reports.
-#end
 #else
 Compatibility summary is unavailable in this build. Run `mvn verify site` to generate the compatibility reports.
 #end


### PR DESCRIPTION
This pull request updates how compatibility summary data is loaded and improves the handling of missing compatibility reports in the `index.md.vm` and `compatibility.md.vm` site documentation files. The main changes include switching from file existence checks to using the `$xml.fetch` method, and simplifying the logic for displaying messages when compatibility data is unavailable.

**Compatibility summary data loading:**

* Updated both `index.md.vm` and `compatibility.md.vm` to use `$xml.fetch("file:///${summaryPath}")` for loading the compatibility summary, removing the previous file existence check and `$xml.read` usage. [[1]](diffhunk://#diff-fd75a7a452ab0c127d2b594ad8a63cc0bbecff4a84652e9aab6b0267c7be1031L32-L38) [[2]](diffhunk://#diff-bc10c596d3862c38be68d7cdb55bf7e6e4c419341efe44e39a3d55fff09f9073L15-L23)

**Unavailable data messaging:**

* Simplified and unified the fallback message logic for when compatibility data is unavailable, ensuring only a single message block is shown and removing redundant `#else`/`#end` blocks. [[1]](diffhunk://#diff-fd75a7a452ab0c127d2b594ad8a63cc0bbecff4a84652e9aab6b0267c7be1031L103-L105) [[2]](diffhunk://#diff-bc10c596d3862c38be68d7cdb55bf7e6e4c419341efe44e39a3d55fff09f9073L175-L177)