### PR TITLE
Add List support for Jawk variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ String result = awk.script("{ print toupper($0) }").input("hello world").execute
 
 When writing custom extensions, annotate associative array parameters with `@JawkAssocArray` and declare them as `Map` values rather than concrete map implementations.
 
+Java variables passed to embedded Jawk scripts may include `Map` and `List` values, including nested JSON-like object trees. Lists are materialized as AWK arrays with zero-based numeric indexes.
+
 ## Documentation
 
 - Overview: https://jawk.io/index.html

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -165,6 +165,7 @@ public class AVM implements VariableManager, Closeable {
 		arguments = Collections.emptyList();
 		sortedArrayKeys = this.settings.isUseSortedArrayKeys();
 		baseInitialVariables = new HashMap<String, Object>(this.settings.getVariables());
+		normalizeVariableValues(baseInitialVariables);
 		baseSpecialVariables = JRT.copySpecialVariables(baseInitialVariables);
 		executionInitialVariables = baseInitialVariables;
 		executionSpecialVariables = baseSpecialVariables;
@@ -763,6 +764,7 @@ public class AVM implements VariableManager, Closeable {
 		} else {
 			executionInitialVariables = new HashMap<>(baseInitialVariables);
 			executionInitialVariables.putAll(variableOverrides);
+			normalizeVariableValues(executionInitialVariables);
 
 			Map<String, Object> specialOverrides = JRT.copySpecialVariables(variableOverrides);
 			if (specialOverrides.isEmpty()) {
@@ -770,6 +772,7 @@ public class AVM implements VariableManager, Closeable {
 			} else {
 				executionSpecialVariables = new HashMap<>(baseSpecialVariables);
 				executionSpecialVariables.putAll(specialOverrides);
+				normalizeVariableValues(executionSpecialVariables);
 			}
 		}
 	}
@@ -811,8 +814,9 @@ public class AVM implements VariableManager, Closeable {
 		for (Map.Entry<String, Object> entry : baseInitialVariables.entrySet()) {
 			String name = entry.getKey();
 			if (isPersistentEligibleGlobal(name)) {
-				validateSeededGlobal(name, entry.getValue());
-				basePersistentSeeds.put(name, entry.getValue());
+				Object value = normalizeVariableValue(entry.getValue());
+				validateSeededGlobal(name, value);
+				basePersistentSeeds.put(name, value);
 			}
 		}
 		return basePersistentSeeds;
@@ -834,8 +838,9 @@ public class AVM implements VariableManager, Closeable {
 			for (Map.Entry<String, Object> entry : variableOverrides.entrySet()) {
 				String name = entry.getKey();
 				if (isPersistentEligibleGlobal(name)) {
-					validateSeededGlobal(name, entry.getValue());
-					executionUserSeeds.put(name, entry.getValue());
+					Object value = normalizeVariableValue(entry.getValue());
+					validateSeededGlobal(name, value);
+					executionUserSeeds.put(name, value);
 				}
 			}
 		}
@@ -3055,12 +3060,13 @@ public class AVM implements VariableManager, Closeable {
 	/** {@inheritDoc} */
 	@Override
 	public final void assignVariable(String name, Object obj) {
+		Object normalized = normalizeVariableValue(obj);
 		// When offsets are not available yet, treat the assignment as part of this
 		// AVM's baseline initial-variable snapshot.
 		if (globalVariableOffsets == null || globalVariableArrays == null) {
-			baseInitialVariables.put(name, obj);
+			baseInitialVariables.put(name, normalized);
 			if (JRT.isJrtManagedSpecialVariable(name)) {
-				baseSpecialVariables.put(name, obj);
+				baseSpecialVariables.put(name, normalized);
 			}
 			return;
 		}
@@ -3075,12 +3081,17 @@ public class AVM implements VariableManager, Closeable {
 
 		if (offsetObj != null) {
 			if (arrayObj.booleanValue()) {
-				throw new IllegalArgumentException("Cannot assign a scalar to a non-scalar variable (" + name + ").");
+				if (normalized instanceof Map) {
+					runtimeStack.setFilelistVariable(offsetObj.intValue(), normalized);
+				} else {
+					throw new IllegalArgumentException(
+							"Cannot assign a scalar to a non-scalar variable (" + name + ").");
+				}
 			} else {
-				runtimeStack.setFilelistVariable(offsetObj.intValue(), obj);
+				runtimeStack.setFilelistVariable(offsetObj.intValue(), normalized);
 			}
 		} else if (runtimeStack.hasGlobalVariable(name)) {
-			runtimeStack.setGlobalVariable(name, obj);
+			runtimeStack.setGlobalVariable(name, normalized);
 		}
 	}
 
@@ -3242,6 +3253,20 @@ public class AVM implements VariableManager, Closeable {
 		@SuppressWarnings("unchecked")
 		Map<Object, Object> nested = (Map<Object, Object>) value;
 		return nested;
+	}
+
+	private void normalizeVariableValues(Map<String, Object> variables) {
+		for (Map.Entry<String, Object> entry : variables.entrySet()) {
+			Object originalValue = entry.getValue();
+			Object normalizedValue = normalizeVariableValue(originalValue);
+			if (normalizedValue != originalValue) {
+				entry.setValue(normalizedValue);
+			}
+		}
+	}
+
+	private Object normalizeVariableValue(Object value) {
+		return AssocArray.normalizeValue(value, sortedArrayKeys);
 	}
 
 	private static final UninitializedObject BLANK = new UninitializedObject();

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -909,7 +909,7 @@ public class AVM implements VariableManager, Closeable {
 	 */
 	private void validateSeededGlobalName(String name) {
 		if (functionNames.contains(name)) {
-			throw new IllegalArgumentException("Cannot assign a scalar to a function name (" + name + ").");
+			throw new IllegalArgumentException("Cannot assign a value to a function name (" + name + ").");
 		}
 	}
 

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -165,7 +165,6 @@ public class AVM implements VariableManager, Closeable {
 		arguments = Collections.emptyList();
 		sortedArrayKeys = this.settings.isUseSortedArrayKeys();
 		baseInitialVariables = new HashMap<String, Object>(this.settings.getVariables());
-		normalizeVariableValues(baseInitialVariables);
 		baseSpecialVariables = JRT.copySpecialVariables(baseInitialVariables);
 		executionInitialVariables = baseInitialVariables;
 		executionSpecialVariables = baseSpecialVariables;
@@ -729,7 +728,7 @@ public class AVM implements VariableManager, Closeable {
 			Integer offsetObj = globalVariableOffsets.get(key);
 			Boolean arrayObj = globalVariableArrays.get(key);
 			if (offsetObj != null) {
-				Object obj = entry.getValue();
+				Object obj = normalizeVariableValue(entry.getValue());
 				if (arrayObj.booleanValue()) {
 					if (obj instanceof Map) {
 						runtimeStack.setFilelistVariable(offsetObj.intValue(), obj);
@@ -764,7 +763,6 @@ public class AVM implements VariableManager, Closeable {
 		} else {
 			executionInitialVariables = new HashMap<>(baseInitialVariables);
 			executionInitialVariables.putAll(variableOverrides);
-			normalizeVariableValues(executionInitialVariables);
 
 			Map<String, Object> specialOverrides = JRT.copySpecialVariables(variableOverrides);
 			if (specialOverrides.isEmpty()) {
@@ -772,7 +770,6 @@ public class AVM implements VariableManager, Closeable {
 			} else {
 				executionSpecialVariables = new HashMap<>(baseSpecialVariables);
 				executionSpecialVariables.putAll(specialOverrides);
-				normalizeVariableValues(executionSpecialVariables);
 			}
 		}
 	}
@@ -3060,10 +3057,10 @@ public class AVM implements VariableManager, Closeable {
 	/** {@inheritDoc} */
 	@Override
 	public final void assignVariable(String name, Object obj) {
-		Object normalized = normalizeVariableValue(obj);
 		// When offsets are not available yet, treat the assignment as part of this
 		// AVM's baseline initial-variable snapshot.
 		if (globalVariableOffsets == null || globalVariableArrays == null) {
+			Object normalized = normalizeVariableValue(obj);
 			baseInitialVariables.put(name, normalized);
 			if (JRT.isJrtManagedSpecialVariable(name)) {
 				baseSpecialVariables.put(name, normalized);
@@ -3080,6 +3077,7 @@ public class AVM implements VariableManager, Closeable {
 		Boolean arrayObj = globalVariableArrays.get(name);
 
 		if (offsetObj != null) {
+			Object normalized = normalizeVariableValue(obj);
 			if (arrayObj.booleanValue()) {
 				if (normalized instanceof Map) {
 					runtimeStack.setFilelistVariable(offsetObj.intValue(), normalized);
@@ -3091,6 +3089,7 @@ public class AVM implements VariableManager, Closeable {
 				runtimeStack.setFilelistVariable(offsetObj.intValue(), normalized);
 			}
 		} else if (runtimeStack.hasGlobalVariable(name)) {
+			Object normalized = normalizeVariableValue(obj);
 			runtimeStack.setGlobalVariable(name, normalized);
 		}
 	}
@@ -3253,16 +3252,6 @@ public class AVM implements VariableManager, Closeable {
 		@SuppressWarnings("unchecked")
 		Map<Object, Object> nested = (Map<Object, Object>) value;
 		return nested;
-	}
-
-	private void normalizeVariableValues(Map<String, Object> variables) {
-		for (Map.Entry<String, Object> entry : variables.entrySet()) {
-			Object originalValue = entry.getValue();
-			Object normalizedValue = normalizeVariableValue(originalValue);
-			if (normalizedValue != originalValue) {
-				entry.setValue(normalizedValue);
-			}
-		}
 	}
 
 	private Object normalizeVariableValue(Object value) {

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -811,8 +811,9 @@ public class AVM implements VariableManager, Closeable {
 		for (Map.Entry<String, Object> entry : baseInitialVariables.entrySet()) {
 			String name = entry.getKey();
 			if (isPersistentEligibleGlobal(name)) {
+				validateSeededGlobalName(name);
 				Object value = normalizeVariableValue(entry.getValue());
-				validateSeededGlobal(name, value);
+				validateSeededGlobalValue(name, value);
 				basePersistentSeeds.put(name, value);
 			}
 		}
@@ -835,8 +836,9 @@ public class AVM implements VariableManager, Closeable {
 			for (Map.Entry<String, Object> entry : variableOverrides.entrySet()) {
 				String name = entry.getKey();
 				if (isPersistentEligibleGlobal(name)) {
+					validateSeededGlobalName(name);
 					Object value = normalizeVariableValue(entry.getValue());
-					validateSeededGlobal(name, value);
+					validateSeededGlobalValue(name, value);
 					executionUserSeeds.put(name, value);
 				}
 			}
@@ -899,16 +901,26 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	/**
-	 * Validates that a seeded global value is compatible with the compiled
-	 * metadata of the current program.
+	 * Validates that a seeded global name is compatible with the compiled
+	 * metadata of the current program before any value normalization can mutate a
+	 * caller-provided object graph.
 	 *
 	 * @param name variable name to validate
-	 * @param value proposed seeded value
 	 */
-	private void validateSeededGlobal(String name, Object value) {
+	private void validateSeededGlobalName(String name) {
 		if (functionNames.contains(name)) {
 			throw new IllegalArgumentException("Cannot assign a scalar to a function name (" + name + ").");
 		}
+	}
+
+	/**
+	 * Validates that a normalized seeded global value is compatible with the
+	 * compiled metadata of the current program.
+	 *
+	 * @param name variable name to validate
+	 * @param value proposed seeded value after normalization
+	 */
+	private void validateSeededGlobalValue(String name, Object value) {
 		Boolean arrayObj = globalVariableArrays.get(name);
 		if (Boolean.TRUE.equals(arrayObj) && !(value instanceof Map)) {
 			throw new IllegalArgumentException("Cannot assign a scalar to a non-scalar variable (" + name + ").");

--- a/src/main/java/io/jawk/jrt/AssocArray.java
+++ b/src/main/java/io/jawk/jrt/AssocArray.java
@@ -22,6 +22,7 @@ package io.jawk.jrt;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.util.List;
 import java.util.Map;
 import io.jawk.intermediate.UninitializedObject;
 
@@ -39,6 +40,8 @@ import io.jawk.intermediate.UninitializedObject;
  * </p>
  * <ul>
  * <li>{@link HashAssocArray} &mdash; backed by {@link java.util.HashMap}</li>
+ * <li>{@link ListAssocArray} &mdash; materialized from a {@link java.util.List}
+ * and backed by {@link java.util.HashMap}</li>
  * <li>{@link SortedAssocArray} &mdash; backed by {@link java.util.TreeMap} with
  * AWK key ordering</li>
  * </ul>
@@ -49,6 +52,7 @@ import io.jawk.intermediate.UninitializedObject;
  * <pre>
  * AssocArray hash = AssocArray.createHash();
  * AssocArray sorted = AssocArray.createSorted();
+ * AssocArray list = AssocArray.createFromList(values, sortedArrayKeys);
  * AssocArray aa = AssocArray.create(sortedArrayKeys);
  * </pre>
  *
@@ -212,6 +216,40 @@ public interface AssocArray extends Map<Object, Object> {
 	 */
 	static AssocArray create(boolean sortedArrayKeys) {
 		return sortedArrayKeys ? createSorted() : createHash();
+	}
+
+	/**
+	 * Creates a new associative array materialized from a Java {@link List}.
+	 * <p>
+	 * List elements are stored under zero-based {@link Long} keys. Nested
+	 * {@link List} values are recursively materialized as associative arrays so
+	 * JSON-like object trees can be traversed with AWK array syntax.
+	 * </p>
+	 *
+	 * @param values list values to expose as an AWK array
+	 * @param sortedArrayKeys {@code true} to create a sorted array, {@code false}
+	 *        for a hash-backed array
+	 * @return a new {@link AssocArray} containing the list values
+	 */
+	static AssocArray createFromList(List<?> values, boolean sortedArrayKeys) {
+		return ListAssocArray.createFromList(values, sortedArrayKeys);
+	}
+
+	/**
+	 * Normalizes an externally supplied structured value before the AVM stores it.
+	 * <p>
+	 * {@link List} values are converted to {@link AssocArray} instances.
+	 * {@link Map} values are kept in place to preserve direct-map performance, but
+	 * their nested list values are recursively converted.
+	 * </p>
+	 *
+	 * @param value value to normalize
+	 * @param sortedArrayKeys {@code true} when converted lists should use sorted
+	 *        array keys
+	 * @return the normalized value
+	 */
+	static Object normalizeValue(Object value, boolean sortedArrayKeys) {
+		return ListAssocArray.normalizeValue(value, sortedArrayKeys);
 	}
 
 }

--- a/src/main/java/io/jawk/jrt/ListAssocArray.java
+++ b/src/main/java/io/jawk/jrt/ListAssocArray.java
@@ -47,7 +47,7 @@ import java.util.Set;
  *
  * @author MetricsHub
  */
-public class ListAssocArray extends HashAssocArray {
+public final class ListAssocArray extends HashAssocArray {
 
 	private static final long serialVersionUID = 1L;
 
@@ -160,8 +160,10 @@ public class ListAssocArray extends HashAssocArray {
 			return;
 		}
 		try {
-			for (int index = 0; index < values.size(); index++) {
-				target.put(Long.valueOf(index), normalizeValue(values.get(index), sortedArrayKeys, activeContainers));
+			long index = 0L;
+			for (Object listValue : values) {
+				target.put(Long.valueOf(index), normalizeValue(listValue, sortedArrayKeys, activeContainers));
+				index++;
 			}
 		} finally {
 			activeContainers.remove(values);
@@ -194,7 +196,13 @@ public class ListAssocArray extends HashAssocArray {
 				Object originalValue = entry.getValue();
 				Object normalizedValue = normalizeValue(originalValue, sortedArrayKeys, activeContainers);
 				if (normalizedValue != originalValue) {
-					entry.setValue(normalizedValue);
+					try {
+						entry.setValue(normalizedValue);
+					} catch (UnsupportedOperationException | ClassCastException ex) {
+						throw new IllegalArgumentException(
+								"Injected maps must be mutable when nested List values need to be materialized as AWK arrays.",
+								ex);
+					}
 				}
 			}
 		} finally {

--- a/src/main/java/io/jawk/jrt/ListAssocArray.java
+++ b/src/main/java/io/jawk/jrt/ListAssocArray.java
@@ -1,0 +1,218 @@
+package io.jawk.jrt;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright 2006 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An AWK associative array materialized from a Java {@link List}.
+ * <p>
+ * The source list is copied once into normal AWK array storage using zero-based
+ * {@link Long} keys. After construction, this array behaves like any other
+ * {@link AssocArray}: scripts may add string keys, delete entries, or create
+ * sparse numeric indexes without being constrained by {@link List} semantics.
+ * </p>
+ * <p>
+ * This class also owns normalization of nested Java containers supplied from
+ * embedding APIs. Java {@link Map} instances remain map-backed for performance,
+ * while nested {@link List} instances are replaced by materialized
+ * {@link AssocArray} instances. Recursive object graphs are guarded with an
+ * identity-based recursion stack so self-referencing maps or lists do not cause
+ * infinite conversion.
+ * </p>
+ *
+ * @author MetricsHub
+ */
+public class ListAssocArray extends HashAssocArray {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Creates a hash-backed associative array from the supplied list.
+	 *
+	 * @param values list values to expose as an AWK array
+	 */
+	public ListAssocArray(List<?> values) {
+		populateFromList(this, values, false, newActiveContainers());
+	}
+
+	/**
+	 * Creates an empty hash-backed instance for factory methods that populate the
+	 * array with a shared recursion guard.
+	 */
+	private ListAssocArray() {}
+
+	/**
+	 * Creates an associative array from the supplied list, honoring the runtime
+	 * key-ordering setting.
+	 *
+	 * @param values list values to expose as an AWK array
+	 * @param sortedArrayKeys {@code true} to use sorted AWK array keys
+	 * @return an AWK associative array containing the list values under zero-based
+	 *         {@link Long} keys
+	 */
+	static AssocArray createFromList(List<?> values, boolean sortedArrayKeys) {
+		AssocArray array = sortedArrayKeys ? AssocArray.createSorted() : new ListAssocArray();
+		populateFromList(array, values, sortedArrayKeys, newActiveContainers());
+		return array;
+	}
+
+	/**
+	 * Normalizes a value supplied from Java before it is stored in the AVM.
+	 * <p>
+	 * Lists are materialized as AWK arrays. Maps are kept as the original map
+	 * instance for the existing no-copy fast path, but their values are scanned so
+	 * nested lists can be materialized too.
+	 * </p>
+	 *
+	 * @param value value to normalize
+	 * @param sortedArrayKeys {@code true} when materialized lists should use
+	 *        sorted AWK array keys
+	 * @return the normalized value
+	 */
+	static Object normalizeValue(Object value, boolean sortedArrayKeys) {
+		return normalizeValue(value, sortedArrayKeys, newActiveContainers());
+	}
+
+	/**
+	 * Normalizes one value within a potentially nested object graph.
+	 *
+	 * @param value value to normalize
+	 * @param sortedArrayKeys {@code true} when materialized lists should use
+	 *        sorted AWK array keys
+	 * @param activeContainers identity-based set of maps/lists currently being
+	 *        traversed; used only as a recursion stack to break cycles
+	 * @return the normalized value
+	 */
+	private static Object normalizeValue(Object value, boolean sortedArrayKeys, Set<Object> activeContainers) {
+		if (value instanceof List) {
+			return createFromList((List<?>) value, sortedArrayKeys, activeContainers);
+		}
+		if (value instanceof Map) {
+			normalizeMapValues(value, sortedArrayKeys, activeContainers);
+		}
+		return value;
+	}
+
+	/**
+	 * Creates an associative array from a nested list while sharing the caller's
+	 * recursion stack.
+	 *
+	 * @param values list values to expose as an AWK array
+	 * @param sortedArrayKeys {@code true} to use sorted AWK array keys
+	 * @param activeContainers identity-based set of maps/lists currently being
+	 *        traversed
+	 * @return an AWK associative array containing the list values, or an empty
+	 *         array when a recursive reference to the same list is detected
+	 */
+	private static AssocArray createFromList(List<?> values, boolean sortedArrayKeys, Set<Object> activeContainers) {
+		AssocArray array = sortedArrayKeys ? AssocArray.createSorted() : new ListAssocArray();
+		populateFromList(array, values, sortedArrayKeys, activeContainers);
+		return array;
+	}
+
+	/**
+	 * Copies a Java list into an AWK associative array using zero-based
+	 * {@link Long} keys.
+	 * <p>
+	 * {@code activeContainers} is intentionally a recursion stack, not a permanent
+	 * visited set. The same Java list may appear in two different branches of the
+	 * input graph and should be materialized in both places. It is skipped only
+	 * when it appears again while already being copied, which indicates a cycle.
+	 * </p>
+	 *
+	 * @param target associative array to populate
+	 * @param values list values to copy; {@code null} leaves {@code target} empty
+	 * @param sortedArrayKeys {@code true} when nested lists should use sorted AWK
+	 *        array keys
+	 * @param activeContainers identity-based recursion stack for maps/lists
+	 */
+	private static void populateFromList(
+			AssocArray target,
+			List<?> values,
+			boolean sortedArrayKeys,
+			Set<Object> activeContainers) {
+		if (values == null || !activeContainers.add(values)) {
+			return;
+		}
+		try {
+			for (int index = 0; index < values.size(); index++) {
+				target.put(Long.valueOf(index), normalizeValue(values.get(index), sortedArrayKeys, activeContainers));
+			}
+		} finally {
+			activeContainers.remove(values);
+		}
+	}
+
+	/**
+	 * Converts nested lists inside a Java map while preserving the map instance
+	 * itself.
+	 * <p>
+	 * Preserving the map keeps direct map insertion and retrieval fast in the AVM.
+	 * Only map values that actually change, normally nested lists, are written
+	 * back. The map is removed from {@code activeContainers} in {@code finally}
+	 * so another branch can still normalize the same shared map later.
+	 * </p>
+	 *
+	 * @param value map value to normalize in place
+	 * @param sortedArrayKeys {@code true} when materialized lists should use
+	 *        sorted AWK array keys
+	 * @param activeContainers identity-based recursion stack for maps/lists
+	 */
+	private static void normalizeMapValues(Object value, boolean sortedArrayKeys, Set<Object> activeContainers) {
+		if (!activeContainers.add(value)) {
+			return;
+		}
+		@SuppressWarnings("unchecked")
+		Map<Object, Object> map = (Map<Object, Object>) value;
+		try {
+			for (Map.Entry<Object, Object> entry : map.entrySet()) {
+				Object originalValue = entry.getValue();
+				Object normalizedValue = normalizeValue(originalValue, sortedArrayKeys, activeContainers);
+				if (normalizedValue != originalValue) {
+					entry.setValue(normalizedValue);
+				}
+			}
+		} finally {
+			activeContainers.remove(value);
+		}
+	}
+
+	/**
+	 * Creates the recursion stack used during normalization.
+	 * <p>
+	 * Identity comparison is required here. Calling {@link Object#equals(Object)}
+	 * on arbitrary maps or lists can be expensive, can treat separate but equal
+	 * containers as the same object, and can itself recurse on cyclic structures.
+	 * </p>
+	 *
+	 * @return an empty identity-based set for active container objects
+	 */
+	private static Set<Object> newActiveContainers() {
+		return Collections.newSetFromMap(new IdentityHashMap<Object, Boolean>());
+	}
+}

--- a/src/main/java/io/jawk/jsr223/JawkScriptEngine.java
+++ b/src/main/java/io/jawk/jsr223/JawkScriptEngine.java
@@ -30,6 +30,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.script.AbstractScriptEngine;
 import javax.script.Bindings;
@@ -147,6 +148,6 @@ public class JawkScriptEngine extends AbstractScriptEngine {
 	}
 
 	private static boolean isSupportedBindingValue(Object value) {
-		return value instanceof String || value instanceof Number || value instanceof Map;
+		return value instanceof String || value instanceof Number || value instanceof Map || value instanceof List;
 	}
 }

--- a/src/main/java/io/jawk/util/AwkSettings.java
+++ b/src/main/java/io/jawk/util/AwkSettings.java
@@ -61,11 +61,14 @@ public class AwkSettings {
 	 * The values may be of type <code>Integer</code>,
 	 * <code>Double</code>, <code>String</code>,
 	 * {@link io.jawk.jrt.AssocArray} (for array variables),
-	 * or any {@link java.util.Map} that Jawk exposes directly to the script.
+	 * any {@link java.util.Map} that Jawk exposes directly to the script,
+	 * or any {@link java.util.List} that Jawk materializes as an array with
+	 * zero-based {@link java.lang.Long} keys.
 	 * <p>
 	 * When a {@link java.util.Map} is provided, the Jawk runtime may mutate it
 	 * during execution. Callers must therefore supply a mutable map
-	 * implementation. Numeric indices written by the runtime into such maps use
+	 * implementation. Numeric indices written by the runtime into such maps and
+	 * indices derived from {@link java.util.List} values use
 	 * {@link java.lang.Long} keys (for example, <code>0L</code>,
 	 * <code>1L</code>, ...).
 	 * </p>
@@ -180,7 +183,9 @@ public class AwkSettings {
 	 * The values may be of type <code>Integer</code>,
 	 * <code>Double</code>, <code>String</code>,
 	 * {@link io.jawk.jrt.AssocArray} (for array variables),
-	 * or any {@link java.util.Map} that Jawk exposes directly to the script.
+	 * any {@link java.util.Map} that Jawk exposes directly to the script,
+	 * or any {@link java.util.List} that Jawk materializes as an array with
+	 * zero-based {@link java.lang.Long} keys.
 	 *
 	 * @return the variables
 	 */
@@ -211,7 +216,9 @@ public class AwkSettings {
 	 * The values may be of type <code>Integer</code>,
 	 * <code>Double</code>, <code>String</code>,
 	 * {@link io.jawk.jrt.AssocArray} (for array variables),
-	 * or any {@link java.util.Map} that Jawk exposes directly to the script.
+	 * any {@link java.util.Map} that Jawk exposes directly to the script,
+	 * or any {@link java.util.List} that Jawk materializes as an array with
+	 * zero-based {@link java.lang.Long} keys.
 	 *
 	 * @param variables the variables to set
 	 */

--- a/src/site/markdown/java-variables.md
+++ b/src/site/markdown/java-variables.md
@@ -53,9 +53,21 @@ Awk awk = new Awk(settings);
 Object result = awk.eval("threshold");
 ```
 
-Values may be scalars such as `Long`, `Double`, and `String`, or associative-array-style values such as mutable `Map` instances and `AssocArray`.
+Values may be scalars such as `Long`, `Double`, and `String`, or associative-array-style values such as mutable `Map` instances, `List` instances, and `AssocArray`.
 
 When you pass a plain Java `Map`, Jawk exposes it directly to the script. The runtime may mutate that map, so do not pass immutable map implementations. Numeric AWK array indexes are represented as `Long` keys (e.g. `0L`, `1L`, `2L`).
+
+When you pass a Java `List`, Jawk materializes it as an AWK associative array with zero-based `Long` indexes. This matches JSON array indexing in common Java JSON parsers while preserving normal AWK array behavior for writes, deletes, sparse indexes, and string keys:
+
+```java
+List<String> values = Arrays.asList("aaa", "bbb", "ccc");
+
+String result = awk.script("BEGIN { print values[0] }")
+        .variable("values", values)
+        .execute();
+```
+
+Nested `Map` and `List` values are supported, so JSON-like object trees can be traversed with array syntax such as `payload["items"][0]["name"]`.
 
 ## Per-Call Variable Overrides
 

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -24,7 +24,9 @@ package io.jawk;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 import io.jawk.intermediate.UninitializedObject;
@@ -97,6 +99,27 @@ public class AssocArrayTest {
 	}
 
 	@Test
+	public void testCreateAssocArrayFromListUsesZeroBasedIndexes() {
+		AssocArray array = AssocArray.createFromList(Arrays.asList("aaa", "bbb", "ccc"), false);
+
+		assertEquals("aaa", array.get(0L));
+		assertEquals("bbb", array.get("1"));
+		assertEquals("ccc", array.get(2L));
+	}
+
+	@Test
+	public void testNormalizeMapValueKeepsMapAndConvertsNestedList() {
+		Map<Object, Object> data = new LinkedHashMap<>();
+		data.put("items", Arrays.asList("aaa", "bbb", "ccc"));
+
+		Object normalized = AssocArray.normalizeValue(data, false);
+
+		assertSame(data, normalized);
+		assertTrue(data.get("items") instanceof AssocArray);
+		assertEquals("bbb", ((AssocArray) data.get("items")).get(1L));
+	}
+
+	@Test
 	public void testInjectAssocArrayVariable() throws Exception {
 		AssocArray data = AssocArray.createHash();
 		data.put("key1", "hello");
@@ -121,6 +144,49 @@ public class AssocArrayTest {
 				.script("BEGIN{ print arr[\"a\"], arr[\"b\"] }")
 				.preassign("arr", data)
 				.expectLines("alpha beta")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testInjectListVariableUsesZeroBasedIndexes() throws Exception {
+		List<String> data = Arrays.asList("aaa", "bbb", "ccc");
+
+		AwkTestSupport
+				.awkTest("inject List into array variable with zero-based indexes")
+				.script("BEGIN{ print arr[0], arr[2], length(arr), (3 in arr) }")
+				.preassign("arr", data)
+				.expectLines("aaa ccc 3 0")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testInjectMapOfListVariable() throws Exception {
+		Map<Object, Object> data = new LinkedHashMap<>();
+		data.put("items", Arrays.asList("aaa", "bbb", "ccc"));
+
+		AwkTestSupport
+				.awkTest("inject Map containing List into nested array variable")
+				.script("BEGIN{ print payload[\"items\"][0], payload[\"items\"][2] }")
+				.preassign("payload", data)
+				.expectLines("aaa ccc")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testInjectListOfMapVariable() throws Exception {
+		Map<Object, Object> first = new LinkedHashMap<>();
+		first.put("name", "alpha");
+		first.put("id", Long.valueOf(1L));
+		Map<Object, Object> second = new LinkedHashMap<>();
+		second.put("name", "beta");
+		second.put("id", Long.valueOf(2L));
+		List<Object> data = Arrays.<Object>asList(first, second);
+
+		AwkTestSupport
+				.awkTest("inject List containing Map into nested array variable")
+				.script("BEGIN{ print payload[0][\"name\"], payload[1][\"id\"] }")
+				.preassign("payload", data)
+				.expectLines("alpha 2")
 				.runAndAssert();
 	}
 

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -25,12 +25,15 @@ package io.jawk;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 import io.jawk.intermediate.UninitializedObject;
 import io.jawk.jrt.AssocArray;
+import io.jawk.jrt.AwkRuntimeException;
 
 public class AssocArrayTest {
 
@@ -160,6 +163,18 @@ public class AssocArrayTest {
 	}
 
 	@Test
+	public void testInjectLinkedListVariableUsesZeroBasedIndexes() throws Exception {
+		List<String> data = new LinkedList<>(Arrays.asList("aaa", "bbb", "ccc"));
+
+		AwkTestSupport
+				.awkTest("inject LinkedList into array variable with zero-based indexes")
+				.script("BEGIN{ print arr[0], arr[2], length(arr) }")
+				.preassign("arr", data)
+				.expectLines("aaa ccc 3")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testInjectMapOfListVariable() throws Exception {
 		Map<Object, Object> data = new LinkedHashMap<>();
 		data.put("items", Arrays.asList("aaa", "bbb", "ccc"));
@@ -170,6 +185,54 @@ public class AssocArrayTest {
 				.preassign("payload", data)
 				.expectLines("aaa ccc")
 				.runAndAssert();
+	}
+
+	@Test
+	public void testInjectImmutableMapOfListVariableThrowsClearException() throws Exception {
+		Map<Object, Object> mutableData = new LinkedHashMap<>();
+		mutableData.put("items", Arrays.asList("aaa", "bbb", "ccc"));
+		Map<Object, Object> data = Collections.unmodifiableMap(mutableData);
+
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.awkTest("inject immutable Map containing List should throw")
+				.script("BEGIN{ print payload[\"items\"][0] }")
+				.preassign("payload", data)
+				.expectThrow(AwkRuntimeException.class)
+				.run();
+		result.assertExpected();
+
+		assertTrue(result.thrownException().getMessage().contains("Injected maps must be mutable"));
+		assertTrue(mutableData.get("items") instanceof List);
+	}
+
+	@Test
+	public void testRejectedFunctionNameAssignmentDoesNotNormalizeMapValue() throws Exception {
+		Map<Object, Object> data = new LinkedHashMap<>();
+		data.put("items", Arrays.asList("aaa", "bbb", "ccc"));
+
+		AwkTestSupport
+				.awkTest("rejected function name assignment leaves Map value unchanged")
+				.script("function payload(){ return 1 } BEGIN{ print \"unused\" }")
+				.preassign("payload", data)
+				.expectThrow(AwkRuntimeException.class)
+				.runAndAssert();
+
+		assertTrue(data.get("items") instanceof List);
+	}
+
+	@Test
+	public void testIgnoredVariableAssignmentDoesNotNormalizeMapValue() throws Exception {
+		Map<Object, Object> data = new LinkedHashMap<>();
+		data.put("items", Arrays.asList("aaa", "bbb", "ccc"));
+
+		AwkTestSupport
+				.awkTest("ignored variable assignment leaves Map value unchanged")
+				.script("BEGIN{ print \"ok\" }")
+				.preassign("payload", data)
+				.expectLines("ok")
+				.runAndAssert();
+
+		assertTrue(data.get("items") instanceof List);
 	}
 
 	@Test

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1537,6 +1537,62 @@ public class AwkTest {
 	}
 
 	@Test
+	public void executePersistingGlobalsRejectedBaselineFunctionNameDoesNotNormalizeMapValue() throws Exception {
+		Map<Object, Object> data = new LinkedHashMap<>();
+		data.put("items", Arrays.asList("aaa", "bbb", "ccc"));
+		AwkSettings settings = new AwkSettings();
+		settings.putVariable("payload", data);
+		Awk configuredAwk = new Awk(settings);
+		AwkProgram program = configuredAwk.compile("function payload(){ return 1 } BEGIN { print \"unused\" }");
+
+		try (AVM avm = configuredAwk.createAvm()) {
+			assertThrows(IllegalArgumentException.class, () -> executePersistent(avm, program));
+		}
+
+		assertTrue(data.get("items") instanceof List);
+	}
+
+	@Test
+	public void executePersistingGlobalsRejectedOverrideFunctionNameDoesNotNormalizeMapValue() throws Exception {
+		Map<Object, Object> data = new LinkedHashMap<>();
+		data.put("items", Arrays.asList("aaa", "bbb", "ccc"));
+		Map<String, Object> overrides = new LinkedHashMap<>();
+		overrides.put("payload", data);
+		AwkProgram program = AWK.compile("function payload(){ return 1 } BEGIN { print \"unused\" }");
+
+		try (AVM avm = AWK.createAvm()) {
+			assertThrows(
+					IllegalArgumentException.class,
+					() -> executePersistent(
+							avm,
+							program,
+							Collections.<String>emptyList(),
+							overrides,
+							emptyInputSource()));
+		}
+
+		assertTrue(data.get("items") instanceof List);
+	}
+
+	@Test
+	public void executePersistingGlobalsAcceptsListSeedForArrayGlobal() throws Exception {
+		Map<String, Object> overrides = new LinkedHashMap<>();
+		overrides.put("arr", Arrays.asList("aaa", "bbb", "ccc"));
+		AwkProgram program = AWK.compile("BEGIN { print arr[0], arr[2] }");
+
+		try (AVM avm = AWK.createAvm()) {
+			assertEquals(
+					"aaa ccc\n",
+					executePersistent(
+							avm,
+							program,
+							Collections.<String>emptyList(),
+							overrides,
+							emptyInputSource()));
+		}
+	}
+
+	@Test
 	public void executePersistingGlobalsDoesNotPersistBuiltInsAndKeepsArraysOnlyForGlobals() throws Exception {
 		AwkProgram writeBuiltIn = AWK.compile("BEGIN { NR = 99; print NR }");
 		AwkProgram readBuiltIn = AWK.compile("BEGIN { print NR }");

--- a/src/test/java/io/jawk/ScriptEngineTest.java
+++ b/src/test/java/io/jawk/ScriptEngineTest.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import javax.script.Bindings;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -54,5 +55,22 @@ public class ScriptEngineTest {
 		engine.eval(script, bindings);
 
 		assertEquals("HELLO WORLD\n", result.toString());
+	}
+
+	@Test
+	public void testJawkScriptEngineAcceptsListBinding() throws Exception {
+		ScriptEngineManager manager = new ScriptEngineManager();
+		ScriptEngine engine = manager.getEngineByName("jawk");
+		assertNotNull("Jawk ScriptEngine not found", engine);
+
+		Bindings bindings = engine.createBindings();
+		bindings.put("values", Arrays.asList("aaa", "bbb", "ccc"));
+
+		StringWriter result = new StringWriter();
+		engine.getContext().setWriter(new PrintWriter(result));
+
+		engine.eval("BEGIN { print values[1] }", bindings);
+
+		assertEquals("bbb\n", result.toString());
 	}
 }


### PR DESCRIPTION
## Summary
- Add support for passing Java `List` values into embedded Jawk scripts.
- Materialize lists as AWK arrays with zero-based `Long` indexes while preserving direct `Map` handling.
- Support nested `Map`/`List` object trees and document the behavior in README and site docs.
- Add unit coverage for list variables, nested map/list structures, and script engine bindings.

## Testing
- Added unit tests for `AssocArray`, `AVM`-driven variable injection, and `JawkScriptEngine` list bindings.
- Verified the updated test suite with Maven unit tests and project verification.