### PR TITLE
Expand JMH coverage for JRT and AVM hot paths

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DEFAULT_JMH_PATTERN: .
+  DEFAULT_JMH_PATTERN: .*
   BENCHMARK_SITE_URL: https://jawk.io/
 
 jobs:
@@ -121,7 +121,11 @@ jobs:
             echo "Benchmark jar was not created." >&2
             exit 1
           fi
-          java -jar "${benchmark_jar}" "${JMH_PATTERN}" ${JMH_ARGS} -rf json -rff target/benchmarks/jmh-results.json
+          jmh_pattern_args=()
+          if [ -n "${JMH_PATTERN}" ] && [ "${JMH_PATTERN}" != "${DEFAULT_JMH_PATTERN}" ]; then
+            jmh_pattern_args+=("${JMH_PATTERN}")
+          fi
+          java -jar "${benchmark_jar}" "${jmh_pattern_args[@]}" ${JMH_ARGS} -rf json -rff target/benchmarks/jmh-results.json
 
       - name: Capture benchmark environment
         shell: bash

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  DEFAULT_JMH_PATTERN: .*
+  DEFAULT_JMH_PATTERN: .
   BENCHMARK_SITE_URL: https://jawk.io/
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ defaults:
 env:
   AUTO_RELEASE_AFTER_CLOSE: true
   BENCHMARK_SITE_URL: https://jawk.io/
-  DEFAULT_JMH_PATTERN: .*
+  DEFAULT_JMH_PATTERN: .
   JDK_VERSION: "17"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ defaults:
 env:
   AUTO_RELEASE_AFTER_CLOSE: true
   BENCHMARK_SITE_URL: https://jawk.io/
-  DEFAULT_JMH_PATTERN: .
+  DEFAULT_JMH_PATTERN: .*
   JDK_VERSION: "17"
 
 jobs:
@@ -144,7 +144,11 @@ jobs:
             echo "Benchmark jar was not created." >&2
             exit 1
           fi
-          java -jar "${benchmark_jar}" "${JMH_PATTERN}" ${JMH_ARGS} -rf json -rff target/benchmarks/jmh-results.json
+          jmh_pattern_args=()
+          if [ -n "${JMH_PATTERN}" ] && [ "${JMH_PATTERN}" != "${DEFAULT_JMH_PATTERN}" ]; then
+            jmh_pattern_args+=("${JMH_PATTERN}")
+          fi
+          java -jar "${benchmark_jar}" "${jmh_pattern_args[@]}" ${JMH_ARGS} -rf json -rff target/benchmarks/jmh-results.json
           rm -f "${benchmark_jar}"
 
       - name: Capture benchmark environment

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
 				<version>2.7.1</version>
 				<configuration>
 					<licenseName>lgpl_v3</licenseName>
+					<copyrightStringFormat>Copyright (C) %1$s %2$s</copyrightStringFormat>
 					<includes>
 						<include>main/java/**/*.java</include>
 						<include>test/java/**/*.java</include>

--- a/src/jmh/java/io/jawk/AwkScriptBenchmark.java
+++ b/src/jmh/java/io/jawk/AwkScriptBenchmark.java
@@ -4,7 +4,7 @@ package io.jawk;
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * Jawk
  * ჻჻჻჻჻჻
- * Copyright 2006 - 2026 MetricsHub
+ * Copyright (C) 2006 - 2026 MetricsHub
  * ჻჻჻჻჻჻
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as

--- a/src/jmh/java/io/jawk/AwkScriptBenchmark.java
+++ b/src/jmh/java/io/jawk/AwkScriptBenchmark.java
@@ -1,0 +1,106 @@
+package io.jawk;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright 2006 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Microbenchmarks for short, precompiled AWK scripts that exercise runtime input
+ * traversal, expression evaluation, and output formatting together.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class AwkScriptBenchmark {
+
+	private Awk awk;
+	private AwkProgram sumInputProgram;
+	private AwkProgram projectMatchingProgram;
+	private String mixedNumericInput;
+
+	/**
+	 * Compiles benchmark scripts once and initializes stable input records.
+	 *
+	 * @throws IOException if script compilation fails
+	 */
+	@Setup(Level.Trial)
+	public void setup() throws IOException {
+		this.awk = new Awk();
+		this.sumInputProgram = this.awk
+				.compile(
+						"BEGIN { total = 0; }\n"
+								+ "/^input/ { total += $2; }\n"
+								+ "END { print total; }\n");
+		this.projectMatchingProgram = this.awk
+				.compile(
+						"/^input/ { print $1, $2 + 1, ($2 ~ /^[0-9]/) }\n");
+		this.mixedNumericInput = "input 10\n"
+				+ "input 3.14\n"
+				+ "input 0\n"
+				+ "input -2\n"
+				+ "input 1e02\n"
+				+ "input non-numeric\n"
+				+ "comment 1000000\n"
+				+ "input 0xff\n";
+	}
+
+	/**
+	 * Measures a simple numeric aggregation script over mixed input records.
+	 *
+	 * @return script output
+	 * @throws IOException if execution fails
+	 * @throws ExitException if the script exits non-zero
+	 */
+	@Benchmark
+	public String sumInputValues() throws IOException, ExitException {
+		return this.awk.script(this.sumInputProgram).input(this.mixedNumericInput).execute();
+	}
+
+	/**
+	 * Measures field projection with numeric coercion and regular expression
+	 * matching over the same stable input records.
+	 *
+	 * @return script output
+	 * @throws IOException if execution fails
+	 * @throws ExitException if the script exits non-zero
+	 */
+	@Benchmark
+	public String projectMatchingValues() throws IOException, ExitException {
+		return this.awk.script(this.projectMatchingProgram).input(this.mixedNumericInput).execute();
+	}
+}

--- a/src/jmh/java/io/jawk/backend/AVMExpressionBenchmark.java
+++ b/src/jmh/java/io/jawk/backend/AVMExpressionBenchmark.java
@@ -1,0 +1,172 @@
+package io.jawk.backend;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright 2006 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import io.jawk.Awk;
+import io.jawk.AwkExpression;
+import io.jawk.util.AwkSettings;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Microbenchmarks for compiled expression evaluation through the
+ * {@link AVM#prepareForEval(String)} and {@link AVM#eval(AwkExpression)} path
+ * used by embedding callers.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class AVMExpressionBenchmark {
+
+	private AVM avm;
+	private AwkExpression literalAddition;
+	private AwkExpression fieldAddition;
+	private AwkExpression fieldMultiplication;
+	private AwkExpression fieldConcatenation;
+	private AwkExpression fieldRegexMatch;
+	private AwkExpression multiStringConcatenation;
+	private AwkExpression mixedExpression;
+
+	/**
+	 * Compiles expressions once and creates the reusable interpreter used by this
+	 * benchmark state.
+	 *
+	 * @throws IOException if expression compilation or input preparation fails
+	 */
+	@Setup(Level.Trial)
+	public void setup() throws IOException {
+		Awk awk = new Awk();
+		this.literalAddition = awk.compileExpression("1 + 2");
+		this.fieldAddition = awk.compileExpression("$1 + 1");
+		this.fieldMultiplication = awk.compileExpression("$1 * 2");
+		this.fieldConcatenation = awk.compileExpression("$1 \" test\"");
+		this.fieldRegexMatch = awk.compileExpression("$1 ~ /test/");
+		this.multiStringConcatenation = awk.compileExpression("$1 \" test1\" \" test2\" \" test3\"");
+		this.mixedExpression = awk.compileExpression("($1 + $2) \":\" ($3 ~ /test/) \":\" $4");
+		this.avm = new AVM(new AwkSettings(), Collections.emptyMap());
+		this.avm.prepareForEval("42 3.14 test-value suffix");
+	}
+
+	/**
+	 * Closes the reusable interpreter after the benchmark trial.
+	 *
+	 * @throws IOException if closing runtime resources fails
+	 */
+	@TearDown(Level.Trial)
+	public void tearDown() throws IOException {
+		this.avm.close();
+	}
+
+	/**
+	 * Measures literal numeric addition through the compiled expression path.
+	 *
+	 * @return expression result
+	 * @throws IOException if input preparation or evaluation fails
+	 */
+	@Benchmark
+	public Object literalAddition() throws IOException {
+		return this.avm.eval(this.literalAddition);
+	}
+
+	/**
+	 * Measures field-to-number conversion followed by addition.
+	 *
+	 * @return expression result
+	 * @throws IOException if input preparation or evaluation fails
+	 */
+	@Benchmark
+	public Object fieldAddition() throws IOException {
+		return this.avm.eval(this.fieldAddition);
+	}
+
+	/**
+	 * Measures field-to-number conversion followed by multiplication.
+	 *
+	 * @return expression result
+	 * @throws IOException if input preparation or evaluation fails
+	 */
+	@Benchmark
+	public Object fieldMultiplication() throws IOException {
+		return this.avm.eval(this.fieldMultiplication);
+	}
+
+	/**
+	 * Measures field string concatenation with a literal suffix.
+	 *
+	 * @return expression result
+	 * @throws IOException if input preparation or evaluation fails
+	 */
+	@Benchmark
+	public Object fieldConcatenation() throws IOException {
+		return this.avm.eval(this.fieldConcatenation);
+	}
+
+	/**
+	 * Measures field regular expression matching.
+	 *
+	 * @return expression result
+	 * @throws IOException if input preparation or evaluation fails
+	 */
+	@Benchmark
+	public Object fieldRegexMatch() throws IOException {
+		return this.avm.eval(this.fieldRegexMatch);
+	}
+
+	/**
+	 * Measures a longer chain of string concatenation operations.
+	 *
+	 * @return expression result
+	 * @throws IOException if input preparation or evaluation fails
+	 */
+	@Benchmark
+	public Object multiStringConcatenation() throws IOException {
+		return this.avm.eval(this.multiStringConcatenation);
+	}
+
+	/**
+	 * Measures mixed numeric, string, field, and regular expression operations.
+	 *
+	 * @return expression result
+	 * @throws IOException if input preparation or evaluation fails
+	 */
+	@Benchmark
+	public Object mixedExpression() throws IOException {
+		return this.avm.eval(this.mixedExpression);
+	}
+}

--- a/src/jmh/java/io/jawk/backend/AVMExpressionBenchmark.java
+++ b/src/jmh/java/io/jawk/backend/AVMExpressionBenchmark.java
@@ -4,7 +4,7 @@ package io.jawk.backend;
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * Jawk
  * ჻჻჻჻჻჻
- * Copyright 2006 - 2026 MetricsHub
+ * Copyright (C) 2006 - 2026 MetricsHub
  * ჻჻჻჻჻჻
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as

--- a/src/jmh/java/io/jawk/jrt/JRTCompare2Benchmark.java
+++ b/src/jmh/java/io/jawk/jrt/JRTCompare2Benchmark.java
@@ -41,8 +41,8 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Fork(2)
 @State(Scope.Thread)
 public class JRTCompare2Benchmark {

--- a/src/jmh/java/io/jawk/jrt/JRTHotPathBenchmark.java
+++ b/src/jmh/java/io/jawk/jrt/JRTHotPathBenchmark.java
@@ -1,0 +1,488 @@
+package io.jawk.jrt;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright 2006 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.PrintStream;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import io.jawk.Awk;
+import io.jawk.intermediate.UninitializedObject;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Microbenchmarks for small {@link JRT} conversion and truthiness helpers that
+ * are frequently exercised by generated AWK runtime code.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class JRTHotPathBenchmark {
+
+	private Object longValue;
+	private Object integerValue;
+	private Object doubleValue;
+	private Object integerString;
+	private Object decimalString;
+	private Object exponentString;
+	private Object nonNumericString;
+	private Object emptyString;
+	private Object zeroLong;
+	private Object zeroDouble;
+	private Object zeroString;
+	private Object uninitialized;
+	private double integralDouble;
+	private double fractionalDouble;
+	private double largeIntegralDouble;
+	private JRT jrt;
+	private Pattern inputPattern;
+
+	/**
+	 * Initializes benchmark operands as mutable state fields so benchmark bodies
+	 * do not feed compile-time constants directly to the JIT.
+	 */
+	@Setup(Level.Trial)
+	public void setup() {
+		this.longValue = Long.valueOf(123456789L);
+		this.integerValue = Integer.valueOf(12345);
+		this.doubleValue = Double.valueOf(123.75D);
+		this.integerString = "123456789";
+		this.decimalString = "12345.75";
+		this.exponentString = "1.25e6";
+		this.nonNumericString = "not-a-number";
+		this.emptyString = "";
+		this.zeroLong = Long.valueOf(0L);
+		this.zeroDouble = Double.valueOf(0.0D);
+		this.zeroString = "0";
+		this.uninitialized = new UninitializedObject();
+		this.integralDouble = 123456789D;
+		this.fractionalDouble = 123456.75D;
+		this.largeIntegralDouble = 9007199254740992D;
+		this.jrt = new JRT(new BenchmarkVariableManager(), Locale.US, AwkSink.NOP_SINK, (PrintStream) null);
+		this.jrt.setInputLine("prefix test suffix");
+		this.inputPattern = Pattern.compile("test");
+	}
+
+	/**
+	 * Measures {@link JRT#toDouble(Object)} for a boxed {@link Long}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public double toDoubleLong() {
+		return JRT.toDouble(this.longValue);
+	}
+
+	/**
+	 * Measures {@link JRT#toDouble(Object)} for a boxed {@link Integer}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public double toDoubleInteger() {
+		return JRT.toDouble(this.integerValue);
+	}
+
+	/**
+	 * Measures {@link JRT#toDouble(Object)} for a boxed {@link Double}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public double toDoubleDouble() {
+		return JRT.toDouble(this.doubleValue);
+	}
+
+	/**
+	 * Measures {@link JRT#toDouble(Object)} for an integer string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public double toDoubleIntegerString() {
+		return JRT.toDouble(this.integerString);
+	}
+
+	/**
+	 * Measures {@link JRT#toDouble(Object)} for a decimal string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public double toDoubleDecimalString() {
+		return JRT.toDouble(this.decimalString);
+	}
+
+	/**
+	 * Measures {@link JRT#toDouble(Object)} for exponent notation.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public double toDoubleExponentString() {
+		return JRT.toDouble(this.exponentString);
+	}
+
+	/**
+	 * Measures {@link JRT#toDouble(Object)} for a non-numeric string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public double toDoubleNonNumericString() {
+		return JRT.toDouble(this.nonNumericString);
+	}
+
+	/**
+	 * Measures {@link JRT#toDouble(Object)} for an empty string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public double toDoubleEmptyString() {
+		return JRT.toDouble(this.emptyString);
+	}
+
+	/**
+	 * Measures {@link JRT#toLong(Object)} for a boxed {@link Long}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public long toLongLong() {
+		return JRT.toLong(this.longValue);
+	}
+
+	/**
+	 * Measures {@link JRT#toLong(Object)} for a boxed {@link Integer}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public long toLongInteger() {
+		return JRT.toLong(this.integerValue);
+	}
+
+	/**
+	 * Measures {@link JRT#toLong(Object)} for a boxed {@link Double}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public long toLongDouble() {
+		return JRT.toLong(this.doubleValue);
+	}
+
+	/**
+	 * Measures {@link JRT#toLong(Object)} for an integer string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public long toLongIntegerString() {
+		return JRT.toLong(this.integerString);
+	}
+
+	/**
+	 * Measures {@link JRT#toLong(Object)} for a decimal string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public long toLongDecimalString() {
+		return JRT.toLong(this.decimalString);
+	}
+
+	/**
+	 * Measures {@link JRT#toLong(Object)} for exponent notation.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public long toLongExponentString() {
+		return JRT.toLong(this.exponentString);
+	}
+
+	/**
+	 * Measures {@link JRT#toLong(Object)} for a non-numeric string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public long toLongNonNumericString() {
+		return JRT.toLong(this.nonNumericString);
+	}
+
+	/**
+	 * Measures {@link JRT#isActuallyLong(double)} for an integral double.
+	 *
+	 * @return whether the value is effectively integral
+	 */
+	@Benchmark
+	public boolean isActuallyLongIntegralDouble() {
+		return JRT.isActuallyLong(this.integralDouble);
+	}
+
+	/**
+	 * Measures {@link JRT#isActuallyLong(double)} for a fractional double.
+	 *
+	 * @return whether the value is effectively integral
+	 */
+	@Benchmark
+	public boolean isActuallyLongFractionalDouble() {
+		return JRT.isActuallyLong(this.fractionalDouble);
+	}
+
+	/**
+	 * Measures {@link JRT#isActuallyLong(double)} for a large integral double.
+	 *
+	 * @return whether the value is effectively integral
+	 */
+	@Benchmark
+	public boolean isActuallyLongLargeIntegralDouble() {
+		return JRT.isActuallyLong(this.largeIntegralDouble);
+	}
+
+	/**
+	 * Measures {@link JRT#toBoolean(Object)} for a non-zero boxed {@link Long}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public boolean toBooleanLongNonZero() {
+		return this.jrt.toBoolean(this.longValue);
+	}
+
+	/**
+	 * Measures {@link JRT#toBoolean(Object)} for a zero boxed {@link Long}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public boolean toBooleanLongZero() {
+		return this.jrt.toBoolean(this.zeroLong);
+	}
+
+	/**
+	 * Measures {@link JRT#toBoolean(Object)} for a zero boxed {@link Double}.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public boolean toBooleanDoubleZero() {
+		return this.jrt.toBoolean(this.zeroDouble);
+	}
+
+	/**
+	 * Measures {@link JRT#toBoolean(Object)} for a non-empty string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public boolean toBooleanStringNonEmpty() {
+		return this.jrt.toBoolean(this.nonNumericString);
+	}
+
+	/**
+	 * Measures {@link JRT#toBoolean(Object)} for an empty string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public boolean toBooleanStringEmpty() {
+		return this.jrt.toBoolean(this.emptyString);
+	}
+
+	/**
+	 * Measures {@link JRT#toBoolean(Object)} for a zero-like string.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public boolean toBooleanStringZero() {
+		return this.jrt.toBoolean(this.zeroString);
+	}
+
+	/**
+	 * Measures {@link JRT#toBoolean(Object)} for an uninitialized runtime value.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public boolean toBooleanUninitialized() {
+		return this.jrt.toBoolean(this.uninitialized);
+	}
+
+	/**
+	 * Measures {@link JRT#toBoolean(Object)} for a regular expression matched
+	 * against the current input record.
+	 *
+	 * @return converted value
+	 */
+	@Benchmark
+	public boolean toBooleanPatternMatch() {
+		return this.jrt.toBoolean(this.inputPattern);
+	}
+
+	/**
+	 * Measures {@link JRT#inc(Object)} for a boxed numeric value.
+	 *
+	 * @return incremented value
+	 */
+	@Benchmark
+	public Object incrementBoxedDouble() {
+		return JRT.inc(this.doubleValue);
+	}
+
+	/**
+	 * Measures {@link JRT#inc(Object)} for a numeric string.
+	 *
+	 * @return incremented value
+	 */
+	@Benchmark
+	public Object incrementDecimalString() {
+		return JRT.inc(this.decimalString);
+	}
+
+	/**
+	 * Measures {@link JRT#inc(Object)} for a non-numeric string.
+	 *
+	 * @return incremented value
+	 */
+	@Benchmark
+	public Object incrementNonNumericString() {
+		return JRT.inc(this.nonNumericString);
+	}
+
+	/**
+	 * Minimal variable manager used by the standalone {@link JRT} benchmark.
+	 */
+	private static final class BenchmarkVariableManager implements VariableManager {
+
+		private final Object argc = Long.valueOf(0L);
+		private final Object argv = JRT.createAwkMap(false);
+		private final Object convfmt = Awk.DEFAULT_CONVFMT;
+		private final Object fs = Awk.DEFAULT_FS;
+		private final Object rs = Awk.DEFAULT_RS;
+		private final Object ofs = Awk.DEFAULT_OFS;
+		private final Object ors = Awk.DEFAULT_ORS;
+		private final Object subsep = Awk.DEFAULT_SUBSEP;
+
+		/** {@inheritDoc} */
+		@Override
+		public Object getARGC() {
+			return this.argc;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Object getARGV() {
+			return this.argv;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Object getCONVFMT() {
+			return this.convfmt;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Object getFS() {
+			return this.fs;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Object getRS() {
+			return this.rs;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Object getOFS() {
+			return this.ofs;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Object getORS() {
+			return this.ors;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public Object getSUBSEP() {
+			return this.subsep;
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public void setFILENAME(String fileName) {
+			assignVariable("FILENAME", fileName);
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public void setNF(Integer newNf) {
+			assignVariable("NF", newNf);
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public void incNR() {
+			assignVariable("NR", Long.valueOf(1L));
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public void incFNR() {
+			assignVariable("FNR", Long.valueOf(1L));
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public void resetFNR() {
+			assignVariable("FNR", Long.valueOf(0L));
+		}
+
+		/** {@inheritDoc} */
+		@Override
+		public void assignVariable(String name, Object value) {
+			// No-op: conversion benchmarks do not read AVM-managed globals.
+		}
+	}
+}

--- a/src/jmh/java/io/jawk/jrt/JRTHotPathBenchmark.java
+++ b/src/jmh/java/io/jawk/jrt/JRTHotPathBenchmark.java
@@ -4,7 +4,7 @@ package io.jawk.jrt;
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * Jawk
  * ჻჻჻჻჻჻
- * Copyright 2006 - 2026 MetricsHub
+ * Copyright (C) 2006 - 2026 MetricsHub
  * ჻჻჻჻჻჻
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as


### PR DESCRIPTION
## Summary
- Added focused JMH coverage for `JRT` conversion and truthiness helpers, including numeric strings, boxed numbers, empty/non-numeric values, and regex-backed boolean evaluation.
- Added AVM expression benchmarks that compile expressions once, bind input during setup, and measure only `AVM.eval(...)` on stable records.
- Added short script-level benchmarks for mixed numeric input and adjusted the benchmark workflows so the default JMH pattern publishes all benchmarks.
- Reduced the existing compare benchmark to 2 warmup iterations and 3 measurement iterations.

## Testing
- `mvn formatter:format`
- `mvn -Pbenchmark -DskipTests package`
- `java -jar target\jawk-6.4.01-SNAPSHOT-benchmarks.jar -l .`
- Focused JMH smoke run for `AVMExpressionBenchmark.literalAddition`
- `mvn test`