### PR TITLE
Handle -- and - per POSIX, pass unknown options to ARGV like gawk

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ As in gawk, the gawk-specific syntax is not special in `--posix` mode.
 echo "hello world" | java -jar jawk-${project.version}-standalone.jar '{ print $2 ", " $1 "!" }'
 ```
 
+The CLI follows the POSIX argument conventions: `--` marks the end of options, and the `-` operand designates standard input as an input file (with `FILENAME` set to `-`). As in gawk, once the program text has been supplied (with `-f` or `-L`), an unknown option ends option processing and is passed on to the AWK script through `ARGV`, which makes `#!` interpreter scripts work. See the [CLI documentation](https://jawk.io/cli.html) for details.
+
 ## Java Example
 
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,38 @@
 						<groupId>org.sentrysoftware.maven</groupId>
 						<artifactId>maven-skin-tools</artifactId>
 						<version>1.7.00</version>
+						<!-- maven-skin-tools 1.7.00 brings GraalJS / Truffle 23.0.11,
+						     which calls sun.misc.Unsafe.ensureClassInitialized,
+						     a method removed in JDK 22 (JDK-8316160). Exclude the
+						     legacy GraalVM stack and replace it below with a
+						     JDK 25-compatible release. -->
+						<exclusions>
+							<exclusion>
+								<groupId>org.graalvm.js</groupId>
+								<artifactId>js</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>org.graalvm.js</groupId>
+								<artifactId>js-scriptengine</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>org.graalvm.truffle</groupId>
+								<artifactId>truffle-api</artifactId>
+							</exclusion>
+						</exclusions>
+					</dependency>
+					<!-- Modern (JDK 25-compatible) GraalVM polyglot stack to feed
+					     IndexTool. Replaces the legacy org.graalvm.js:js artifacts. -->
+					<dependency>
+						<groupId>org.graalvm.polyglot</groupId>
+						<artifactId>polyglot</artifactId>
+						<version>24.2.2</version>
+					</dependency>
+					<dependency>
+						<groupId>org.graalvm.polyglot</groupId>
+						<artifactId>js</artifactId>
+						<version>24.2.2</version>
+						<type>pom</type>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -414,39 +414,7 @@
 					<dependency>
 						<groupId>org.sentrysoftware.maven</groupId>
 						<artifactId>maven-skin-tools</artifactId>
-						<version>1.7.00</version>
-						<!-- maven-skin-tools 1.7.00 brings GraalJS / Truffle 23.0.11,
-						     which calls sun.misc.Unsafe.ensureClassInitialized,
-						     a method removed in JDK 22 (JDK-8316160). Exclude the
-						     legacy GraalVM stack and replace it below with a
-						     JDK 25-compatible release. -->
-						<exclusions>
-							<exclusion>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js</artifactId>
-							</exclusion>
-							<exclusion>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js-scriptengine</artifactId>
-							</exclusion>
-							<exclusion>
-								<groupId>org.graalvm.truffle</groupId>
-								<artifactId>truffle-api</artifactId>
-							</exclusion>
-						</exclusions>
-					</dependency>
-					<!-- Modern (JDK 25-compatible) GraalVM polyglot stack to feed
-					     IndexTool. Replaces the legacy org.graalvm.js:js artifacts. -->
-					<dependency>
-						<groupId>org.graalvm.polyglot</groupId>
-						<artifactId>polyglot</artifactId>
-						<version>24.2.2</version>
-					</dependency>
-					<dependency>
-						<groupId>org.graalvm.polyglot</groupId>
-						<artifactId>js</artifactId>
-						<version>24.2.2</version>
-						<type>pom</type>
+						<version>1.8.00</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/src/main/java/io/jawk/Cli.java
+++ b/src/main/java/io/jawk/Cli.java
@@ -220,7 +220,12 @@ public final class Cli {
 				// end of options: remaining args are part of the script execution
 				break;
 			} else if (arg.equals("-")) {
-				// single dash indicates end of options as well
+				// single dash is the standard-input operand (POSIX): end of
+				// options, and keep it so it is processed as an input file
+				break;
+			} else if (arg.equals("--")) {
+				// POSIX end-of-options marker: the remaining args are part of
+				// the script execution
 				++argIdx;
 				break;
 			} else if (arg.equals("-v")) {
@@ -321,6 +326,12 @@ public final class Cli {
 				printUsage = true;
 				return;
 			} else {
+				// Like gawk: once the program text has been supplied, an
+				// unknown option ends option processing and is passed on to
+				// the AWK program through ARGV (useful for '#!' scripts)
+				if (!scriptSources.isEmpty() || precompiledProgram != null) {
+					break;
+				}
 				throw new IllegalArgumentException("Unknown parameter: " + arg);
 			}
 			++argIdx;
@@ -619,8 +630,9 @@ public final class Cli {
 								" [-t]" +
 								" [-l extension]..." +
 								" [-v name=val]..." +
+								" [--]" +
 								" [script]" +
-								" [name=val | input_filename]...");
+								" [name=val | input_filename | -]...");
 		dest.println();
 		dest.println("java -jar " + JAR_NAME + " --list-ext");
 		dest.println();
@@ -638,6 +650,8 @@ public final class Cli {
 		dest.println(" --load extension = Same as -l.");
 		dest.println("                      Extensions must already be on the class path before loading them.");
 		dest.println(" -v name=val = Initial awk variable assignments.");
+		dest.println(" -- = End of options: the remaining arguments are the script and its operands.");
+		dest.println(" - = As an operand, read input from standard input.");
 		dest.println();
 		dest.println(" -t = (extension) Maintain array keys in sorted order.");
 		dest.println(" -K filename = Compile to program file and halt.");

--- a/src/main/java/io/jawk/jrt/StreamInputSource.java
+++ b/src/main/java/io/jawk/jrt/StreamInputSource.java
@@ -566,12 +566,17 @@ public class StreamInputSource implements InputSource, Closeable {
 	 * @throws IOException if the file cannot be opened for reading
 	 */
 	private PartitioningReader openFileListReader(String arg) throws IOException {
-		currentReaderIsDefaultInput = "-".equals(arg);
-		InputStream stream = currentReaderIsDefaultInput ? defaultInput : new FileInputStream(arg);
-		return new PartitioningReader(
+		boolean isDefaultInput = "-".equals(arg);
+		// Open the stream before publishing the flag: if the open fails, the
+		// still-current reader must keep its own classification, so that
+		// cleanup does not close the caller-provided default input stream.
+		InputStream stream = isDefaultInput ? defaultInput : new FileInputStream(arg);
+		PartitioningReader reader = new PartitioningReader(
 				new InputStreamReader(stream, StandardCharsets.UTF_8),
 				jrt.getRSString(),
 				true);
+		currentReaderIsDefaultInput = isDefaultInput;
+		return reader;
 	}
 
 	/**

--- a/src/main/java/io/jawk/jrt/StreamInputSource.java
+++ b/src/main/java/io/jawk/jrt/StreamInputSource.java
@@ -70,6 +70,7 @@ public class StreamInputSource implements InputSource, Closeable {
 
 	// Current reader and record
 	private PartitioningReader partitioningReader;
+	private boolean currentReaderIsDefaultInput;
 	private boolean currentFromFilenameList;
 	private String currentRecord;
 	private boolean currentReaderExhausted;
@@ -337,6 +338,7 @@ public class StreamInputSource implements InputSource, Closeable {
 					partitioningReader = new PartitioningReader(
 							new InputStreamReader(defaultInput, StandardCharsets.UTF_8),
 							jrt.getRSString());
+					currentReaderIsDefaultInput = true;
 					jrt.setFILENAMEViaJrt(jrt.toInputScalar(""));
 					// gawk clears ERRNO whenever the main input advances
 					// successfully
@@ -355,6 +357,7 @@ public class StreamInputSource implements InputSource, Closeable {
 					partitioningReader = new PartitioningReader(
 							new InputStreamReader(defaultInput, StandardCharsets.UTF_8),
 							jrt.getRSString());
+					currentReaderIsDefaultInput = true;
 					jrt.setFILENAMEViaJrt(jrt.toInputScalar(""));
 					// gawk clears ERRNO whenever the main input advances
 					// successfully
@@ -363,10 +366,7 @@ public class StreamInputSource implements InputSource, Closeable {
 				}
 			} else {
 				closeCurrentReaderIfFileStream();
-				partitioningReader = new PartitioningReader(
-						new InputStreamReader(new FileInputStream(arg), StandardCharsets.UTF_8),
-						jrt.getRSString(),
-						true);
+				partitioningReader = openFileListReader(arg);
 				jrt.setFILENAMEViaJrt(jrt.toInputScalar(arg));
 				jrt.setFNR(0L);
 				jrt.setARGIND(Long.valueOf(lastArgumentIndex));
@@ -493,6 +493,7 @@ public class StreamInputSource implements InputSource, Closeable {
 		partitioningReader = new PartitioningReader(
 				new InputStreamReader(defaultInput, StandardCharsets.UTF_8),
 				jrt.getRSString());
+		currentReaderIsDefaultInput = true;
 		currentPresentedToLoop = true;
 		jrt.setFILENAMEViaJrt(jrt.toInputScalar(""));
 		beginFileState(0);
@@ -522,6 +523,14 @@ public class StreamInputSource implements InputSource, Closeable {
 	 *         the file cannot be opened for reading
 	 */
 	private String openCurrentFile(String arg) {
+		if ("-".equals(arg)) {
+			try {
+				partitioningReader = openFileListReader(arg);
+				return null;
+			} catch (IOException e) {
+				return e.getMessage();
+			}
+		}
 		File file = new File(arg);
 		if (file.isDirectory()) {
 			return "Is a directory";
@@ -530,10 +539,7 @@ public class StreamInputSource implements InputSource, Closeable {
 			return "No such file or directory";
 		}
 		try {
-			partitioningReader = new PartitioningReader(
-					new InputStreamReader(new FileInputStream(arg), StandardCharsets.UTF_8),
-					jrt.getRSString(),
-					true);
+			partitioningReader = openFileListReader(arg);
 			return null;
 		} catch (IOException e) {
 			String message = e.getMessage();
@@ -550,12 +556,31 @@ public class StreamInputSource implements InputSource, Closeable {
 	}
 
 	/**
+	 * Opens a reader for the given {@code ARGV} filename entry. The
+	 * conventional {@code -} filename designates the default input stream
+	 * (usually stdin), as required by POSIX; any other name is opened as a
+	 * regular file.
+	 *
+	 * @param arg the filename from the {@code ARGV} file list
+	 * @return a reader presenting the argument as a file-list input
+	 * @throws IOException if the file cannot be opened for reading
+	 */
+	private PartitioningReader openFileListReader(String arg) throws IOException {
+		currentReaderIsDefaultInput = "-".equals(arg);
+		InputStream stream = currentReaderIsDefaultInput ? defaultInput : new FileInputStream(arg);
+		return new PartitioningReader(
+				new InputStreamReader(stream, StandardCharsets.UTF_8),
+				jrt.getRSString(),
+				true);
+	}
+
+	/**
 	 * Closes the current {@link PartitioningReader} if it wraps a file stream
 	 * (not {@code defaultInput}). This prevents file-descriptor leaks when
 	 * traversing multiple ARGV files.
 	 */
 	private void closeCurrentReaderIfFileStream() {
-		if (partitioningReader != null && partitioningReader.fromFilenameList()) {
+		if (partitioningReader != null && partitioningReader.fromFilenameList() && !currentReaderIsDefaultInput) {
 			try {
 				partitioningReader.close();
 			} catch (IOException ignored) {

--- a/src/site/markdown/cli-reference.md
+++ b/src/site/markdown/cli-reference.md
@@ -15,7 +15,7 @@ This page documents the CLI surface implemented by [`Cli`](apidocs/io/jawk/Cli.h
 The common command shape is:
 
 ```shell
-java -jar jawk-${project.version}-standalone.jar [options] [script] [name=value | input_filename]...
+java -jar jawk-${project.version}-standalone.jar [options] [--] [script] [name=value | input_filename | -]...
 ```
 
 The extension listing mode is separate:
@@ -37,10 +37,13 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 >
 > - Input and `ARGV`
 >
+>   - `--` marks the end of options (POSIX): every following argument is the script (when `-f` or `-L` was not used) and its operands.
 >   - Remaining operands after the script are exposed through `ARGV` and `ARGC`.
 >   - An operand without `=` is treated as an input filename.
+>   - The `-` operand designates standard input as an input file (POSIX). `FILENAME` is `-` while it is being read.
 >   - An operand containing `=` is treated as an AWK-style file-list assignment that applies before the next input file is consumed.
 >   - Use `-v name=value` instead when the variable must exist before `BEGIN`.
+>   - As in gawk, once the program text has been supplied (with `-f` or `-L`), an unknown option ends option processing and is passed on to the AWK program through `ARGV`, which is useful for `#!` interpreter scripts.
 >
 > - Variables and formatting
 >
@@ -69,7 +72,7 @@ java -jar jawk-${project.version}-standalone.jar --list-ext
 > - Help and errors
 >
 >   - `-h` and `-?` print usage and exit. They must be used by themselves.
->   - Missing option arguments, unknown parameters, invalid `-v` syntax, or missing scripts cause argument parsing to fail.
+>   - Missing option arguments, invalid `-v` syntax, or missing scripts cause argument parsing to fail. An unknown option is rejected only when no program text has been supplied yet; otherwise it flows to `ARGV` as described above.
 >   - Jawk reports runtime problems through exceptions and exits with a non-zero status when execution fails.
 
 ## Execution Notes

--- a/src/site/markdown/cli.md
+++ b/src/site/markdown/cli.md
@@ -65,6 +65,12 @@ $ printf "alpha\nbeta\n" | java -jar jawk-${project.version}-standalone.jar '{ p
 2:beta
 ```
 
+You can also request standard input explicitly with the `-` operand, which makes it possible to interleave it with regular input files. `FILENAME` is `-` while standard input is being read:
+
+```shell-session
+$ echo "from stdin" | java -jar jawk-${project.version}-standalone.jar '{ print FILENAME ":" $0 }' before.txt - after.txt
+```
+
 ## Read Input Files
 
 Input filenames passed after the script become runtime operands and are processed as AWK input files:
@@ -74,6 +80,14 @@ $ java -jar jawk-${project.version}-standalone.jar -F : '{ print FILENAME ":" FN
 ```
 
 Jawk follows the usual AWK distinction between the script itself and the remaining operands. Files and `name=value` operands after the script are visible through `ARGV` and `ARGC`.
+
+Use `--` to mark the end of options when the script or the first operand could otherwise be mistaken for an option:
+
+```shell-session
+$ java -jar jawk-${project.version}-standalone.jar -f totals.awk -- values.txt
+```
+
+As in gawk, once the program text has been supplied with `-f` or `-L`, an unknown option also ends option processing and is passed on to the AWK program through `ARGV`, which is useful for `#!` interpreter scripts.
 
 ### BEGINFILE and ENDFILE Rules
 

--- a/src/test/java/io/jawk/AwkTestSupport.java
+++ b/src/test/java/io/jawk/AwkTestSupport.java
@@ -530,9 +530,24 @@ public final class AwkTestSupport {
 		private final Map<String, Object> assignments = new LinkedHashMap<>();
 		private final Map<String, String> environment = new LinkedHashMap<>();
 		private boolean redirectErrorStream;
+		private InputStream stdinStream;
 
 		private CliTestBuilder(String description) {
 			super(description);
+		}
+
+		/**
+		 * Supplies the raw standard-input stream handed to the CLI under test.
+		 * Use this instead of {@link #stdin(String)} when the test must observe
+		 * interactions with the stream itself, such as tracking whether the CLI
+		 * closes the caller-provided stream.
+		 *
+		 * @param stream the input stream the CLI reads program input from
+		 * @return this builder for method chaining
+		 */
+		public CliTestBuilder stdin(InputStream stream) {
+			this.stdinStream = stream;
+			return this;
 		}
 
 		/**
@@ -619,7 +634,8 @@ public final class AwkTestSupport {
 					argumentSpecs,
 					assignments,
 					environment,
-					redirectErrorStream);
+					redirectErrorStream,
+					stdinStream);
 		}
 	}
 
@@ -1116,6 +1132,7 @@ public final class AwkTestSupport {
 		private final Map<String, Object> assignments;
 		private final Map<String, String> environment;
 		private final boolean redirectErrorStream;
+		private final InputStream stdinStream;
 
 		CliTestCase(
 				TestLayout layout,
@@ -1126,20 +1143,27 @@ public final class AwkTestSupport {
 				List<String> argumentSpecs,
 				Map<String, Object> assignments,
 				Map<String, String> environment,
-				boolean redirectErrorStream) {
+				boolean redirectErrorStream,
+				InputStream stdinStream) {
 			super(layout, fileContents, operandSpecs, pathPlaceholders, requiresPosix);
 			this.argumentSpecs = new ArrayList<>(argumentSpecs);
 			this.assignments = new LinkedHashMap<>(assignments);
 			this.environment = new LinkedHashMap<>(environment);
 			this.redirectErrorStream = redirectErrorStream;
+			this.stdinStream = stdinStream;
 		}
 
 		@Override
 		protected ActualResult execute(ExecutionEnvironment env) throws Exception {
 			String stdin = resolvedStdin(env);
-			InputStream in = stdin != null ?
-					new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)) :
-					new ByteArrayInputStream(new byte[0]);
+			InputStream in;
+			if (stdinStream != null) {
+				in = stdinStream;
+			} else {
+				in = stdin != null ?
+						new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8)) :
+						new ByteArrayInputStream(new byte[0]);
+			}
 			ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
 			ByteArrayOutputStream errBytes = new ByteArrayOutputStream();
 			Map<String, String> resolvedEnvironment = new LinkedHashMap<String, String>();

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -151,6 +151,92 @@ public class CliOptionTest {
 	}
 
 	@Test
+	public void doubleDashEndsOptionProcessing() {
+		Cli cli = new Cli();
+		// After "--", "-v" is no longer an option: it becomes the inline script
+		cli.parse(new String[] { "--", "-v" });
+
+		assertEquals(1, cli.getScriptSources().size());
+	}
+
+	@Test
+	public void doubleDashPassesRemainingArgumentsToArgv() throws Exception {
+		AwkTestSupport
+				.cliTest("CLI -- passes remaining arguments to ARGV")
+				.file("argv.awk", "BEGIN { for (i = 1; i < ARGC; i++) print i \"=\" ARGV[i] }")
+				.argument("-f", "{{argv.awk}}", "--")
+				.operand("-v", "x=1")
+				.expectLines("1=-v", "2=x=1")
+				.runAndAssert();
+	}
+
+	@Test
+	public void singleDashOperandReadsStandardInput() throws Exception {
+		AwkTestSupport
+				.cliTest("CLI - operand reads standard input")
+				.script("{ print FILENAME \":\" $0 }")
+				.operand("-")
+				.stdin("hello\n")
+				.expectLines("-:hello")
+				.runAndAssert();
+	}
+
+	@Test
+	public void singleDashOperandMixesWithRegularFiles() throws Exception {
+		AwkTestSupport
+				.cliTest("CLI - operand mixes with regular input files")
+				.script("{ print FILENAME \":\" FNR \":\" $0 }")
+				.file("data.txt", "a\n")
+				.operand("-", "{{data.txt}}")
+				.stdin("s\n")
+				.expectLines("-:1:s", "{{data.txt}}:1:a")
+				.runAndAssert();
+	}
+
+	@Test
+	public void singleDashOperandWorksWithBeginFileRules() throws Exception {
+		AwkTestSupport
+				.cliTest("CLI - operand works with BEGINFILE rules")
+				.script("BEGINFILE { print \"BF:\" FILENAME } { print $0 }")
+				.operand("-")
+				.stdin("s\n")
+				.expectLines("BF:-", "s")
+				.runAndAssert();
+	}
+
+	@Test
+	public void singleDashBeforeScriptIsTreatedAsScript() throws Exception {
+		// "-" no longer terminates option processing while being skipped: it is
+		// an operand, so here it is (mis)used as the inline script, like gawk
+		AwkTestSupport
+				.cliTest("CLI - before script is treated as the script")
+				.argument("-", "BEGIN { print \"never\" }")
+				.expectThrow(ParserException.class)
+				.runAndAssert();
+	}
+
+	@Test
+	public void unknownOptionAfterScriptFileIsPassedToArgv() throws Exception {
+		AwkTestSupport
+				.cliTest("CLI unknown option after -f is passed to ARGV")
+				.file("argv.awk", "BEGIN { for (i = 1; i < ARGC; i++) print i \"=\" ARGV[i] }")
+				.argument("-f", "{{argv.awk}}", "-q")
+				.operand("one")
+				.expectLines("1=-q", "2=one")
+				.runAndAssert();
+	}
+
+	@Test
+	public void unknownOptionWithoutScriptIsRejected() {
+		Cli cli = new Cli();
+		IllegalArgumentException ex = assertThrows(
+				IllegalArgumentException.class,
+				() -> cli.parse(new String[]
+				{ "-q", "{ print }" }));
+		assertTrue(ex.getMessage().contains("Unknown parameter: -q"));
+	}
+
+	@Test
 	public void posixOptionDisablesArraysOfArrays() {
 		Cli cli = new Cli();
 		cli.parse(new String[] { "--posix", "{ print 1 }" });

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -221,21 +221,17 @@ public class CliOptionTest {
 	@Test
 	public void unreadableFileAfterStdinOperandDoesNotCloseCallerInput() throws Exception {
 		File missing = new File(tempFolder.getRoot(), "missing.txt");
-		// Direct Cli construction (like persistOptionFlushesOutputBeforeSaveFailure):
-		// the AwkTestSupport builders cannot observe whether the caller-provided
-		// input stream gets closed.
 		CloseTrackingInputStream input = new CloseTrackingInputStream("s\n".getBytes(StandardCharsets.UTF_8));
-		ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
-		Cli cli = new Cli(
-				input,
-				new PrintStream(outBytes, true, StandardCharsets.UTF_8.name()),
-				new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8.name()),
-				Collections.<String, String>emptyMap());
-		cli.parse(new String[] { "{ print }", "-", missing.getAbsolutePath() });
 
-		assertThrows(Exception.class, () -> cli.run());
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.cliTest("CLI unreadable file after - operand keeps caller input open")
+				.stdin(input)
+				.script("{ print }")
+				.operand("-", missing.getAbsolutePath())
+				.expectThrow(Exception.class)
+				.run();
 
-		assertEquals("s\n", outBytes.toString(StandardCharsets.UTF_8.name()));
+		result.assertExpected();
 		assertFalse(input.isClosed());
 	}
 

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -219,6 +219,27 @@ public class CliOptionTest {
 	}
 
 	@Test
+	public void unreadableFileAfterStdinOperandDoesNotCloseCallerInput() throws Exception {
+		File missing = new File(tempFolder.getRoot(), "missing.txt");
+		// Direct Cli construction (like persistOptionFlushesOutputBeforeSaveFailure):
+		// the AwkTestSupport builders cannot observe whether the caller-provided
+		// input stream gets closed.
+		CloseTrackingInputStream input = new CloseTrackingInputStream("s\n".getBytes(StandardCharsets.UTF_8));
+		ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+		Cli cli = new Cli(
+				input,
+				new PrintStream(outBytes, true, StandardCharsets.UTF_8.name()),
+				new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8.name()),
+				Collections.<String, String>emptyMap());
+		cli.parse(new String[] { "{ print }", "-", missing.getAbsolutePath() });
+
+		assertThrows(Exception.class, () -> cli.run());
+
+		assertEquals("s\n", outBytes.toString(StandardCharsets.UTF_8.name()));
+		assertFalse(input.isClosed());
+	}
+
+	@Test
 	public void unknownOptionAfterScriptFileIsPassedToArgv() throws Exception {
 		AwkTestSupport
 				.cliTest("CLI unknown option after -f is passed to ARGV")
@@ -479,6 +500,24 @@ public class CliOptionTest {
 	private static void writeProgram(File target, String script) throws Exception {
 		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(target))) {
 			oos.writeObject(new Awk().compile(script));
+		}
+	}
+
+	private static final class CloseTrackingInputStream extends ByteArrayInputStream {
+		private boolean closed;
+
+		CloseTrackingInputStream(byte[] data) {
+			super(data);
+		}
+
+		@Override
+		public void close() throws IOException {
+			closed = true;
+			super.close();
+		}
+
+		private boolean isClosed() {
+			return closed;
 		}
 	}
 

--- a/src/test/java/io/jawk/CliOptionTest.java
+++ b/src/test/java/io/jawk/CliOptionTest.java
@@ -151,12 +151,15 @@ public class CliOptionTest {
 	}
 
 	@Test
-	public void doubleDashEndsOptionProcessing() {
-		Cli cli = new Cli();
-		// After "--", "-v" is no longer an option: it becomes the inline script
-		cli.parse(new String[] { "--", "-v" });
-
-		assertEquals(1, cli.getScriptSources().size());
+	public void doubleDashEndsOptionProcessing() throws Exception {
+		// After "--", the dash-leading argument is no longer an option: it is
+		// the inline script (without "--" it would be rejected as unknown)
+		AwkTestSupport
+				.cliTest("CLI -- ends option processing")
+				.argument("--", "-1 { print \"ok\" }")
+				.stdin("x\n")
+				.expectLines("ok")
+				.runAndAssert();
 	}
 
 	@Test
@@ -227,13 +230,16 @@ public class CliOptionTest {
 	}
 
 	@Test
-	public void unknownOptionWithoutScriptIsRejected() {
-		Cli cli = new Cli();
-		IllegalArgumentException ex = assertThrows(
-				IllegalArgumentException.class,
-				() -> cli.parse(new String[]
-				{ "-q", "{ print }" }));
-		assertTrue(ex.getMessage().contains("Unknown parameter: -q"));
+	public void unknownOptionWithoutScriptIsRejected() throws Exception {
+		AwkTestSupport.TestResult result = AwkTestSupport
+				.cliTest("CLI unknown option without script is rejected")
+				.argument("-q")
+				.script("{ print }")
+				.expectThrow(IllegalArgumentException.class)
+				.run();
+
+		result.assertExpected();
+		assertTrue(result.thrownException().getMessage().contains("Unknown parameter: -q"));
 	}
 
 	@Test


### PR DESCRIPTION
Closes #114

## What changed

### POSIX/gawk-compliant argument parsing (`Cli`)

- `--` is now the end-of-options marker, as required by POSIX: everything after it is the script (when `-f`/`-L` was not used) and its operands.
- `-` no longer terminates option processing. It is kept as an operand and designates **standard input** as an input file (POSIX). While it is being read, `FILENAME` is `-`, and FNR/ARGIND behave as for a regular file, matching gawk.
- Like gawk, once the program text has been supplied (via `-f` or `-L`), an unknown option ends option processing and is passed on to the AWK program through `ARGV` instead of being rejected. This is what makes `#!/usr/bin/jawk -f` interpreter scripts usable. With no program text yet, an unknown option is still an error.
- Usage/help output documents `--` and `-`.

### Runtime support for the `-` operand (`StreamInputSource`)

The ARGV traversal opens the `-` entry as the default input stream (stdin) instead of a file named `-`, in both the classic record loop and the BEGINFILE/ENDFILE per-file loop. The reader-closing logic never closes the caller's default input stream.

### Site build fixes (opportunistic)

`mvn verify site` failed on JDK 22+ because maven-skin-tools 1.7.00 pulled a legacy GraalJS/Truffle stack that calls `sun.misc.Unsafe.ensureClassInitialized`, removed in JDK 22 (JDK-8316160). Fixed first by excluding the legacy stack (as in metricshub-community-connectors), then simplified to a plain upgrade to maven-skin-tools 1.8.00, which is JDK 25-compatible out of the box (sentrysoftware/maven-skin-tools#111).

## Behavior notes for reviewers

All three parsing behaviors were verified against real gawk 5.x before implementing:

| Command | Before | After (= gawk) |
|---|---|---|
| `jawk -f p.awk -- -v x=1` | error: unknown parameter after `--` consumed as `-v` option | `-v`, `x=1` go to `ARGV` |
| `jawk '{print FILENAME}' -` | tries to open file `-` | reads stdin, `FILENAME` is `-` |
| `jawk -f p.awk -q foo` | error: `Unknown parameter: -q` | `-q`, `foo` go to `ARGV` |
| `jawk - '{print}'` | `-` swallowed, `{print}` is the script | `-` is the script → syntax error (gawk does the same) |
| `jawk -q '{print}'` (no `-f`) | error | error (unchanged) |

The last row is the one intentional breaking change: `-` was previously a Jawk-specific end-of-options marker; scripts relying on that must use `--` instead.

## Testing

- 8 new tests in `CliOptionTest` covering `--`, `-` as stdin (alone, mixed with regular files, and with BEGINFILE rules), unknown-option passthrough to `ARGV`, unknown-option rejection without a script, and the `-`-as-script breaking change.
- Full `mvn verify`: 563 unit tests pass, 0 checkstyle/PMD/SpotBugs violations. Compatibility IT failures are pre-existing and unrelated (regex/locale gaps and the cosmetic `ARGV[0]` "jawk" vs "gawk" difference).
- `mvn site` now passes on JDK 25 (it failed before, even on `main`).

## Documentation

`cli.md` and `cli-reference.md` document `--`, the `-` stdin operand, and the gawk-style unknown-option passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
