### PR TITLE
Print numeric-looking strings verbatim

### DIFF
--- a/.github/scripts/stamp-behavior-changes.sh
+++ b/.github/scripts/stamp-behavior-changes.sh
@@ -21,53 +21,35 @@ if [ ! -f "${file}" ]; then
 	exit 1
 fi
 
-if ! grep -qx "Unreleased" "${file}"; then
-	echo "ERROR: ${file} has no 'Unreleased' section; restore it before releasing." >&2
+if ! grep -qx "## Unreleased" "${file}"; then
+	echo "ERROR: ${file} has no '## Unreleased' section; restore it before releasing." >&2
 	exit 1
 fi
 
-# Count bullet items inside the "Unreleased" section (up to the next setext heading).
+# Count bullet items inside the "## Unreleased" section (up to the next H2).
 bullets="$(awk '
-	{ lines[NR] = $0 }
-	END {
-		inSection = 0
-		count = 0
-		for (i = 1; i <= NR; i++) {
-			if (!inSection && lines[i] == "Unreleased" && lines[i + 1] ~ /^-{4,}$/) {
-				inSection = 1
-				i++
-				continue
-			}
-			if (inSection) {
-				if (i < NR && lines[i] != "" && lines[i + 1] ~ /^-{4,}$/) {
-					break
-				}
-				if (lines[i] ~ /^- /) {
-					count++
-				}
-			}
-		}
-		print count
-	}
+	/^## Unreleased$/ { inSection = 1; next }
+	inSection && /^## / { exit }
+	inSection && /^- / { count++ }
+	END { print count + 0 }
 ' "${file}")"
 
 if [ "${bullets}" -eq 0 ]; then
-	echo "No behavior changes recorded under 'Unreleased'; leaving ${file} unchanged."
+	echo "No behavior changes recorded under '## Unreleased'; leaving ${file} unchanged."
 	exit 0
 fi
 
-# Replace the "Unreleased" heading line with the version heading (reusing the
-# existing setext underline), insert a fresh "Unreleased" stub above it, and
-# drop the placeholder left by a previous stamping from the released section.
+# Replace the "## Unreleased" heading with the version heading, insert a fresh
+# "## Unreleased" stub above it, and drop the placeholder left by a previous
+# stamping from the released section.
 tmp="$(mktemp)"
 awk -v version="${version}" -v releaseDate="${releaseDate}" -v placeholder="${placeholder}" '
-	$0 == "Unreleased" && !stamped {
-		print "Unreleased"
-		print "----------"
+	$0 == "## Unreleased" && !stamped {
+		print "## Unreleased"
 		print ""
 		print placeholder
 		print ""
-		printf "[v%s](https://github.com/jawkio/jawk/releases/tag/v%s) (%s)\n", version, version, releaseDate
+		printf "## [v%s](https://github.com/jawkio/jawk/releases/tag/v%s) (%s)\n", version, version, releaseDate
 		stamped = 1
 		next
 	}
@@ -86,7 +68,7 @@ awk -v version="${version}" -v releaseDate="${releaseDate}" -v placeholder="${pl
 ' "${file}" > "${tmp}"
 mv "${tmp}" "${file}"
 
-if ! grep -qF "[v${version}](https://github.com/jawkio/jawk/releases/tag/v${version}) (${releaseDate})" "${file}"; then
+if ! grep -qF "## [v${version}](https://github.com/jawkio/jawk/releases/tag/v${version}) (${releaseDate})" "${file}"; then
 	echo "ERROR: failed to stamp v${version} in ${file}." >&2
 	exit 1
 fi

--- a/.github/scripts/stamp-behavior-changes.sh
+++ b/.github/scripts/stamp-behavior-changes.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Stamps the "Unreleased" section of the behavior-changes page with the version
+# being released, and inserts a fresh empty "Unreleased" section above it.
+#
+# Called by the release workflow (release.yml) on the release branch, before
+# maven-release-plugin tags the release, so the released site and the
+# post-release pull request back to the default branch both carry the change.
+#
+# If the "Unreleased" section records no behavior changes (no bullet items),
+# the file is left untouched: the page omits releases without user-visible
+# behavior changes.
+set -euo pipefail
+
+version="${1:?usage: stamp-behavior-changes.sh <releaseVersion>}"
+file="src/site/markdown/behavior-changes.md"
+releaseDate="$(date -u +%Y-%m-%d)"
+
+if [ ! -f "${file}" ]; then
+	echo "ERROR: ${file} not found." >&2
+	exit 1
+fi
+
+if ! grep -qx "Unreleased" "${file}"; then
+	echo "ERROR: ${file} has no 'Unreleased' section; restore it before releasing." >&2
+	exit 1
+fi
+
+# Count bullet items inside the "Unreleased" section (up to the next setext heading).
+bullets="$(awk '
+	{ lines[NR] = $0 }
+	END {
+		inSection = 0
+		count = 0
+		for (i = 1; i <= NR; i++) {
+			if (!inSection && lines[i] == "Unreleased" && lines[i + 1] ~ /^-{4,}$/) {
+				inSection = 1
+				i++
+				continue
+			}
+			if (inSection) {
+				if (i < NR && lines[i] != "" && lines[i + 1] ~ /^-{4,}$/) {
+					break
+				}
+				if (lines[i] ~ /^- /) {
+					count++
+				}
+			}
+		}
+		print count
+	}
+' "${file}")"
+
+if [ "${bullets}" -eq 0 ]; then
+	echo "No behavior changes recorded under 'Unreleased'; leaving ${file} unchanged."
+	exit 0
+fi
+
+# Replace the "Unreleased" heading line with the version heading (reusing the
+# existing setext underline), and insert a fresh "Unreleased" stub above it.
+tmp="$(mktemp)"
+awk -v version="${version}" -v releaseDate="${releaseDate}" '
+	$0 == "Unreleased" && !stamped {
+		print "Unreleased"
+		print "----------"
+		print ""
+		print "_No user-visible behavior changes recorded yet._"
+		print ""
+		printf "[v%s](https://github.com/jawkio/jawk/releases/tag/v%s) (%s)\n", version, version, releaseDate
+		stamped = 1
+		next
+	}
+	{ print }
+' "${file}" > "${tmp}"
+mv "${tmp}" "${file}"
+
+if ! grep -qF "[v${version}](https://github.com/jawkio/jawk/releases/tag/v${version}) (${releaseDate})" "${file}"; then
+	echo "ERROR: failed to stamp v${version} in ${file}." >&2
+	exit 1
+fi
+
+echo "Stamped ${bullets} behavior change(s) as v${version} (${releaseDate}) in ${file}."

--- a/.github/scripts/stamp-behavior-changes.sh
+++ b/.github/scripts/stamp-behavior-changes.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 version="${1:?usage: stamp-behavior-changes.sh <releaseVersion>}"
 file="src/site/markdown/behavior-changes.md"
 releaseDate="$(date -u +%Y-%m-%d)"
+placeholder="_No user-visible behavior changes recorded yet._"
 
 if [ ! -f "${file}" ]; then
 	echo "ERROR: ${file} not found." >&2
@@ -56,20 +57,32 @@ if [ "${bullets}" -eq 0 ]; then
 fi
 
 # Replace the "Unreleased" heading line with the version heading (reusing the
-# existing setext underline), and insert a fresh "Unreleased" stub above it.
+# existing setext underline), insert a fresh "Unreleased" stub above it, and
+# drop the placeholder left by a previous stamping from the released section.
 tmp="$(mktemp)"
-awk -v version="${version}" -v releaseDate="${releaseDate}" '
+awk -v version="${version}" -v releaseDate="${releaseDate}" -v placeholder="${placeholder}" '
 	$0 == "Unreleased" && !stamped {
 		print "Unreleased"
 		print "----------"
 		print ""
-		print "_No user-visible behavior changes recorded yet._"
+		print placeholder
 		print ""
 		printf "[v%s](https://github.com/jawkio/jawk/releases/tag/v%s) (%s)\n", version, version, releaseDate
 		stamped = 1
 		next
 	}
-	{ print }
+	stamped && $0 == placeholder {
+		skipBlank = 1
+		next
+	}
+	skipBlank && $0 == "" {
+		skipBlank = 0
+		next
+	}
+	{
+		skipBlank = 0
+		print
+	}
 ' "${file}" > "${tmp}"
 mv "${tmp}" "${file}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,17 @@ jobs:
           git checkout "${branchName}" 2>/dev/null || git checkout -b "${branchName}"
           git push --force origin "${branchName}"
 
+      - name: Stamp behavior changes for v${{ inputs.releaseVersion }}
+        run: |
+          bash .github/scripts/stamp-behavior-changes.sh "${INPUT_RELEASE_VERSION}"
+          if ! git diff --quiet -- src/site/markdown/behavior-changes.md; then
+            git add src/site/markdown/behavior-changes.md
+            git commit -m "Stamp behavior changes for v${INPUT_RELEASE_VERSION}"
+            git push origin "${branchName}"
+          fi
+        env:
+          INPUT_RELEASE_VERSION: ${{ inputs.releaseVersion }}
+
       - name: Clean up existing release tag
         run: |
           git tag -d "${tagName}" || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,6 @@ Code quality checks are performed during the build with `mvn verify` (checkstyle
 
 ## Documentation
 
-Any change that affects the end user of Jawk must be properly documented in README.md and src/site/*.md.
+Always make sure that public API and CLI features are properly documented in src/site/*.md and that README.md is always up-to-date.
 
 Any change to Jawk's user-visible behavior (AWK language semantics, CLI behavior, or output) must also be recorded as a bullet under the `Unreleased` section at the top of src/site/markdown/behavior-changes.md, briefly describing the old and new behavior and linking the issue. Do not rename the `Unreleased` section manually: the release workflow stamps it with the release version automatically (via .github/scripts/stamp-behavior-changes.sh).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,5 @@ Code quality checks are performed during the build with `mvn verify` (checkstyle
 ## Documentation
 
 Any change that affects the end user of Jawk must be properly documented in README.md and src/site/*.md.
+
+Any change to Jawk's user-visible behavior (AWK language semantics, CLI behavior, or output) must also be recorded as a bullet under the `Unreleased` section at the top of src/site/markdown/behavior-changes.md, briefly describing the old and new behavior and linking the issue. Do not rename the `Unreleased` section manually: the release workflow stamps it with the release version automatically (via .github/scripts/stamp-behavior-changes.sh).

--- a/src/it/java/io/jawk/posix/PosixIT.java
+++ b/src/it/java/io/jawk/posix/PosixIT.java
@@ -388,7 +388,7 @@ public class PosixIT {
 		AwkTestSupport
 				.awkTest("33. OFMT vs CONVFMT")
 				.script("BEGIN{OFMT=\"%.2f\"; CONVFMT=\"%.3f\"; x=1.2345; print x; s=x \"\"; print s}")
-				.expectLines("1.23", "1.24")
+				.expectLines("1.23", "1.235")
 				.runAndAssert();
 	}
 

--- a/src/main/java/io/jawk/jrt/AwkSink.java
+++ b/src/main/java/io/jawk/jrt/AwkSink.java
@@ -25,6 +25,7 @@ package io.jawk.jrt;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.math.BigDecimal;
 import java.util.Locale;
 import org.metricshub.printf4j.Printf4J;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -249,6 +250,35 @@ public abstract class AwkSink {
 	 */
 	protected final String formatPrintArgument(Object value, String ofmt) {
 		return formatOutputValue(value, ofmt, locale);
+	}
+
+	/**
+	 * Converts a {@code print} operand that renders as a numeric string into a
+	 * numeric form.
+	 * <p>
+	 * Historical versions of Jawk applied this conversion in plain {@code print},
+	 * which is not what POSIX AWK does: {@code print} outputs string values
+	 * verbatim, and only actual numbers are formatted with {@code OFMT}. The
+	 * built-in sinks therefore no longer call this helper; it is preserved only
+	 * for compatibility with custom sinks compiled against earlier releases.
+	 * </p>
+	 *
+	 * @param value operand to normalize
+	 * @return the normalized value, either unchanged or converted to a numeric form
+	 * @deprecated Plain {@code print} does not numerically coerce string values;
+	 *             use the operand as-is, or {@link #formatPrintArgument(Object, String)}
+	 *             to render it the way {@code print} would.
+	 */
+	@Deprecated
+	protected final Object normalizePrintArgument(Object value) {
+		if (value == null || value instanceof Number) {
+			return value;
+		}
+		try {
+			return Double.valueOf(new BigDecimal(value.toString()).doubleValue());
+		} catch (NumberFormatException e) {
+			return value;
+		}
 	}
 
 	/**

--- a/src/main/java/io/jawk/jrt/AwkSink.java
+++ b/src/main/java/io/jawk/jrt/AwkSink.java
@@ -25,7 +25,6 @@ package io.jawk.jrt;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.math.BigDecimal;
 import java.util.Locale;
 import org.metricshub.printf4j.Printf4J;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -239,9 +238,9 @@ public abstract class AwkSink {
 	/**
 	 * Formats one operand of a plain AWK {@code print} statement.
 	 * <p>
-	 * AWK applies {@code OFMT} not only to numeric values, but also to strings
-	 * that can be interpreted numerically. This helper preserves that behaviour
-	 * for text-based sinks.
+	 * Numeric values are rendered with {@code OFMT} (or as integers when they
+	 * hold an integral value). String values — including numeric strings that
+	 * originate from input — are printed verbatim, as required by POSIX.
 	 * </p>
 	 *
 	 * @param value operand to format
@@ -249,7 +248,7 @@ public abstract class AwkSink {
 	 * @return the textual representation AWK would print for this operand
 	 */
 	protected final String formatPrintArgument(Object value, String ofmt) {
-		return formatOutputValue(normalizePrintArgument(value), ofmt, locale);
+		return formatOutputValue(value, ofmt, locale);
 	}
 
 	/**
@@ -280,29 +279,6 @@ public abstract class AwkSink {
 	 */
 	protected final String formatPrintfResult(String format, Object... values) {
 		return sprintf(format, values);
-	}
-
-	/**
-	 * Converts a {@code print} operand into the value shape AWK uses before it
-	 * applies {@code OFMT}.
-	 * <p>
-	 * When a non-numeric object renders as a numeric string, AWK treats it as a
-	 * number for plain {@code print}. Structured sinks can reuse this helper when
-	 * they want text output compatible with standard AWK behaviour.
-	 * </p>
-	 *
-	 * @param value operand to normalize
-	 * @return the normalized value, either unchanged or converted to a numeric form
-	 */
-	protected final Object normalizePrintArgument(Object value) {
-		if (value == null || value instanceof Number) {
-			return value;
-		}
-		try {
-			return Double.valueOf(new BigDecimal(value.toString()).doubleValue());
-		} catch (NumberFormatException e) {
-			return value;
-		}
 	}
 
 	/**

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -1,8 +1,7 @@
 keywords: behavior, changes, releases, versions, migration, awk, jawk
 description: User-visible behavior changes in each version of Jawk, from newest to oldest.
 
-Behavior Changes by Version
-===========================
+# Behavior Changes by Version
 
 <!-- MACRO{toc|fromDepth=2|toDepth=2|id=toc} -->
 
@@ -19,8 +18,7 @@ hand: the release workflow (.github/workflows/release.yml) stamps it with the
 released version automatically via .github/scripts/stamp-behavior-changes.sh.
 -->
 
-Unreleased
-----------
+## Unreleased
 
 - `print` outputs numeric-looking strings verbatim, as POSIX requires: `print "0100"` now prints
   `0100` (previously `100`), and input-derived values such as `$1` keep their original text.
@@ -35,8 +33,7 @@ Unreleased
   `((i, j) in array)` is accepted as an expression
   ([#535](https://github.com/jawkio/jawk/issues/535)).
 
-[v7.0.00](https://github.com/jawkio/jawk/releases/tag/v7.0.00) (2026-07-30)
-----------
+## [v7.0.00](https://github.com/jawkio/jawk/releases/tag/v7.0.00) (2026-07-30)
 
 - The full set of gawk language extensions is now enabled by default: `BEGINFILE` / `ENDFILE`
   special rules, the `nextfile` statement, the `ERRNO` and `ARGIND` special variables,
@@ -54,28 +51,24 @@ Unreleased
   AWK script in `ARGV` once the program text has been supplied, which makes `#!` interpreter
   scripts work as in gawk.
 
-[v6.4.01](https://github.com/jawkio/jawk/releases/tag/v6.4.01) (2026-06-03)
-----------
+## [v6.4.01](https://github.com/jawkio/jawk/releases/tag/v6.4.01) (2026-06-03)
 
 - Input-derived values (fields, `getline` results, `split()` pieces) now follow POSIX
   "numeric string" (strnum) semantics: they compare numerically when both operands are numeric,
   and as strings otherwise, matching gawk and One True Awk.
 
-[v6.2.00](https://github.com/jawkio/jawk/releases/tag/v6.2.00) (2026-05-04)
-----------
+## [v6.2.00](https://github.com/jawkio/jawk/releases/tag/v6.2.00) (2026-05-04)
 
 - New persistent memory support: the `--persist <file>` CLI option (or the
   `JAWK_PERSISTENT_MEMORY` environment variable) saves user-defined global variables to a file
   and restores them on the next run, in the spirit of gawk's persistent memory feature.
 
-[v6.1.00](https://github.com/jawkio/jawk/releases/tag/v6.1.00) (2026-04-19)
-----------
+## [v6.1.00](https://github.com/jawkio/jawk/releases/tag/v6.1.00) (2026-04-19)
 
 - gawk-style arrays of arrays (`a[i][j]`) are now supported.
 - New `--posix` CLI option.
 
-[v6.0.00](https://github.com/jawkio/jawk/releases/tag/v6.0.00) (2026-04-16)
-----------
+## [v6.0.00](https://github.com/jawkio/jawk/releases/tag/v6.0.00) (2026-04-16)
 
 - Breaking change for Java embedders: the project moved to [jawk.io](https://jawk.io), with new
   Maven coordinates and the `io.jawk` package (previously `org.metricshub.jawk`), and the Java
@@ -83,14 +76,12 @@ Unreleased
   purely behavioral `AwkSettings`).
 - Fixed `print` argument list parsing (argument continuation detection).
 
-[v5.0.00](https://github.com/jawkio/jawk/releases/tag/v5.0.00) (2025-11-04)
-----------
+## [v5.0.00](https://github.com/jawkio/jawk/releases/tag/v5.0.00) (2025-11-04)
 
 - Java embedding API changes only (`AssocArray` became a real `java.util.Map`, refined extension
   metadata APIs); no changes to AWK script behavior.
 
-[v4.1.00](https://github.com/jawkio/jawk/releases/tag/v4.1.00) (2025-09-29)
-----------
+## [v4.1.00](https://github.com/jawkio/jawk/releases/tag/v4.1.00) (2025-09-29)
 
 - Removed the deprecated Jawk-specific language extensions: the `_INTEGER`, `_DOUBLE`, and
   `_STRING` typecast keywords (and the `-y` CLI flag), and the `_sleep` and `_dump` keywords
@@ -100,14 +91,12 @@ Unreleased
 - Environment variables with non-numeric values no longer trigger spurious
   `NumberFormatException` log messages.
 
-[v4.0.01](https://github.com/jawkio/jawk/releases/tag/v4.0.01) (2025-08-08)
-----------
+## [v4.0.01](https://github.com/jawkio/jawk/releases/tag/v4.0.01) (2025-08-08)
 
 - Fixed field splitting with a regex `FS` producing leading or trailing separators, and a
   tokenizer regression, raising One True Awk test-suite compatibility from 94.2% to 97.8%.
 
-[v4.0.00](https://github.com/jawkio/jawk/releases/tag/v4.0.00) (2025-07-29)
-----------
+## [v4.0.00](https://github.com/jawkio/jawk/releases/tag/v4.0.00) (2025-07-29)
 
 A large conformance release aligning Jawk with [One True Awk](https://github.com/onetrueawk/awk):
 
@@ -124,63 +113,53 @@ A large conformance release aligning Jawk with [One True Awk](https://github.com
   comparison.
 - `rand()` produces a deterministic sequence for a given `srand()` seed.
 
-[v3.3.05](https://github.com/jawkio/jawk/releases/tag/v3.3.05) (2025-04-03)
-----------
+## [v3.3.05](https://github.com/jawkio/jawk/releases/tag/v3.3.05) (2025-04-03)
 
 - Java embedders only: packages renamed from `org.sentrysoftware.jawk` to `org.metricshub.jawk`;
   no changes to AWK script behavior.
 
-[v3.3.04](https://github.com/jawkio/jawk/releases/tag/v3.3.04) (2025-02-13)
-----------
+## [v3.3.04](https://github.com/jawkio/jawk/releases/tag/v3.3.04) (2025-02-13)
 
 - Fixed `sub()` with dollar references, and `sub()` / `gsub()` with `&` references in the
   replacement string.
 
-[v3.3.03](https://github.com/jawkio/jawk/releases/tag/v3.3.03) (2024-08-29)
-----------
+## [v3.3.03](https://github.com/jawkio/jawk/releases/tag/v3.3.03) (2024-08-29)
 
 - Fixed `gsub()` on array elements.
 - Removed the spurious SLF4J connection message from standard output.
 
-[v3.3.02](https://github.com/jawkio/jawk/releases/tag/v3.3.02) (2024-08-09)
-----------
+## [v3.3.02](https://github.com/jawkio/jawk/releases/tag/v3.3.02) (2024-08-09)
 
 - Fixed operator associativity: most operations are left-associative, exponentiation (`^`) is
   right-associative.
 
-[v3.3.01](https://github.com/jawkio/jawk/releases/tag/v3.3.01) (2024-08-09)
-----------
+## [v3.3.01](https://github.com/jawkio/jawk/releases/tag/v3.3.01) (2024-08-09)
 
 - `substr()` no longer fails on out-of-range arguments.
 - Output redirection (`>`) is supported within `print` statements.
 - Fixed the argument order in extension function calls.
 
-[v3.3.00](https://github.com/jawkio/jawk/releases/tag/v3.3.00) (2024-02-04)
-----------
+## [v3.3.00](https://github.com/jawkio/jawk/releases/tag/v3.3.00) (2024-02-04)
 
 - Fixed the evaluation order in string concatenation and in function argument lists.
 
-[v3.2.00](https://github.com/jawkio/jawk/releases/tag/v3.2.00) (2024-02-01)
-----------
+## [v3.2.00](https://github.com/jawkio/jawk/releases/tag/v3.2.00) (2024-02-01)
 
 - `exit NN` returns the proper exit code from `BEGIN` and main rules.
 - Full support for the `ORS` special variable.
 - Full support for range patterns (`/start/, /end/`).
 - `NR` is updated even when the program has no main rule.
 
-[v3.1.02](https://github.com/jawkio/jawk/releases/tag/v3.1.02) (2024-01-18)
-----------
+## [v3.1.02](https://github.com/jawkio/jawk/releases/tag/v3.1.02) (2024-01-18)
 
 - `!x` on an uninitialized variable now correctly evaluates to true.
 
-[v3.1.01](https://github.com/jawkio/jawk/releases/tag/v3.1.01) (2024-01-17)
-----------
+## [v3.1.01](https://github.com/jawkio/jawk/releases/tag/v3.1.01) (2024-01-17)
 
 - Fixed escaping in regexp constants, notably octal sequences.
 - Improved syntax error messages.
 
-[v3.1.00](https://github.com/jawkio/jawk/releases/tag/v3.1.00) (2024-01-17)
-----------
+## [v3.1.00](https://github.com/jawkio/jawk/releases/tag/v3.1.00) (2024-01-17)
 
 - Newlines are allowed after `&&`, `||`, `?`, `:`, and `,`.
 - Unary plus (`+a`) is supported.
@@ -189,21 +168,18 @@ A large conformance release aligning Jawk with [One True Awk](https://github.com
 - Fixed parsing of escape sequences in regular expression constants.
 - Jawk runs on Java 8 and later.
 
-[v3.0.00](https://github.com/jawkio/jawk/releases/tag/v3.0.00) (2023-12-14)
-----------
+## [v3.0.00](https://github.com/jawkio/jawk/releases/tag/v3.0.00) (2023-12-14)
 
 - `printf()` and `sprintf()` use the [Printf4J](https://github.com/metricshub/printf4j) library
   for C-style formatting.
 - Java embedders: packages renamed from `org.jawk` to `org.sentrysoftware.jawk`; the library is
   licensed under LGPL and released on Maven Central.
 
-[v2.1.00 (beta)](https://github.com/jawkio/jawk/releases/tag/v2.1.00-SNAPSHOT7) (2023)
-----------
+## [v2.1.00 (beta)](https://github.com/jawkio/jawk/releases/tag/v2.1.00-SNAPSHOT7) (2023)
 
 - Octal (`"\033"`) and hexadecimal (`"\x1B"`) escape sequences are supported in strings.
 
-See Also
---------
+## See Also
 
 - [Compatibility and Compliance](compatibility.html)
 - [GitHub releases](https://github.com/jawkio/jawk/releases)

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -1,0 +1,202 @@
+keywords: behavior, changes, releases, versions, migration, awk, jawk
+description: User-visible behavior changes in each version of Jawk, from newest to oldest.
+
+Behavior Changes by Version
+===========================
+
+<!-- MACRO{toc|fromDepth=2|toDepth=2|id=toc} -->
+
+This page lists the user-visible behavior changes in each version of Jawk: changes to how AWK
+programs parse, execute, and produce output, plus CLI changes and breaking changes for Java
+embedders. Releases that only contain internal refactoring, performance work, build, or
+documentation changes are omitted. For the complete change lists, see the
+[GitHub releases](https://github.com/jawkio/jawk/releases).
+
+Unreleased
+----------
+
+- `print` outputs numeric-looking strings verbatim, as POSIX requires: `print "0100"` now prints
+  `0100` (previously `100`), and input-derived values such as `$1` keep their original text.
+  `OFMT` applies only when printing actual non-integral numbers, and `CONVFMT` governs
+  number-to-string conversion everywhere else
+  ([#529](https://github.com/jawkio/jawk/issues/529)).
+- Range patterns (`begpat, endpat`) evaluate their conditions lazily: the end condition is not
+  evaluated until the range has started, so conditions with side effects behave as in gawk and
+  One True Awk ([#115](https://github.com/jawkio/jawk/issues/115)).
+- `print (a), (b)` parses correctly: a single parenthesized expression followed by a comma
+  continues the output list, a parenthesized group before `in` is a membership key, and
+  `((i, j) in array)` is accepted as an expression
+  ([#535](https://github.com/jawkio/jawk/issues/535)).
+
+[v7.0.00](https://github.com/jawkio/jawk/releases/tag/v7.0.00) (2026-07-30)
+----------
+
+- The full set of gawk language extensions is now enabled by default: `BEGINFILE` / `ENDFILE`
+  special rules, the `nextfile` statement, the `ERRNO` and `ARGIND` special variables,
+  `@include`, `@namespace`, typed regexp literals (`@/re/`), indirect function calls (`@f()`),
+  and gawk-compatible runtime array/scalar typing diagnostics.
+- All gawk built-in functions are now implemented: `asort()`, `asorti()`, `typeof()`,
+  `isarray()`, `mkbool()`, `gensub()`, `patsplit()`, `strtonum()`, `systime()`, `mktime()`,
+  `strftime()`, `bindtextdomain()`, `dcgettext()`, `dcngettext()`, plus `SYMTAB`, `FUNCTAB`,
+  and `PROCINFO["sorted_in"]`-controlled array traversal. As a consequence, these names are
+  reserved by default and can no longer be used as variables (see
+  [Compatibility](compatibility.html)).
+- The new strict `--posix` mode disables all gawk extensions when you want the standard and
+  nothing else.
+- The CLI handles `--` and the `-` operand per POSIX, and passes unknown options through to the
+  AWK script in `ARGV` once the program text has been supplied, which makes `#!` interpreter
+  scripts work as in gawk.
+
+[v6.4.01](https://github.com/jawkio/jawk/releases/tag/v6.4.01) (2026-06-03)
+----------
+
+- Input-derived values (fields, `getline` results, `split()` pieces) now follow POSIX
+  "numeric string" (strnum) semantics: they compare numerically when both operands are numeric,
+  and as strings otherwise, matching gawk and One True Awk.
+
+[v6.2.00](https://github.com/jawkio/jawk/releases/tag/v6.2.00) (2026-05-04)
+----------
+
+- New persistent memory support: the `--persist <file>` CLI option (or the
+  `JAWK_PERSISTENT_MEMORY` environment variable) saves user-defined global variables to a file
+  and restores them on the next run, in the spirit of gawk's persistent memory feature.
+
+[v6.1.00](https://github.com/jawkio/jawk/releases/tag/v6.1.00) (2026-04-19)
+----------
+
+- gawk-style arrays of arrays (`a[i][j]`) are now supported.
+- New `--posix` CLI option.
+
+[v6.0.00](https://github.com/jawkio/jawk/releases/tag/v6.0.00) (2026-04-16)
+----------
+
+- Breaking change for Java embedders: the project moved to [jawk.io](https://jawk.io), with new
+  Maven coordinates and the `io.jawk` package (previously `org.metricshub.jawk`), and the Java
+  API was overhauled (`AwkSink` for customized output, `InputSource` for structured input, and a
+  purely behavioral `AwkSettings`).
+- Fixed `print` argument list parsing (argument continuation detection).
+
+[v5.0.00](https://github.com/jawkio/jawk/releases/tag/v5.0.00) (2025-11-04)
+----------
+
+- Java embedding API changes only (`AssocArray` became a real `java.util.Map`, refined extension
+  metadata APIs); no changes to AWK script behavior.
+
+[v4.1.00](https://github.com/jawkio/jawk/releases/tag/v4.1.00) (2025-09-29)
+----------
+
+- Removed the deprecated Jawk-specific language extensions: the `_INTEGER`, `_DOUBLE`, and
+  `_STRING` typecast keywords (and the `-y` CLI flag), and the `_sleep` and `_dump` keywords
+  (and the `-x` CLI flag).
+- Removed the logging framework: Jawk no longer emits SLF4J messages; runtime warnings go to
+  standard error.
+- Environment variables with non-numeric values no longer trigger spurious
+  `NumberFormatException` log messages.
+
+[v4.0.01](https://github.com/jawkio/jawk/releases/tag/v4.0.01) (2025-08-08)
+----------
+
+- Fixed field splitting with a regex `FS` producing leading or trailing separators, and a
+  tokenizer regression, raising One True Awk test-suite compatibility from 94.2% to 97.8%.
+
+[v4.0.00](https://github.com/jawkio/jawk/releases/tag/v4.0.00) (2025-07-29)
+----------
+
+A large conformance release aligning Jawk with [One True Awk](https://github.com/onetrueawk/awk):
+
+- Statements and control flow: `getline` without an lvalue, `exit` code handling, early-exit
+  logic, pattern negation, range (condition pair) evaluation, post-increment/decrement on
+  uninitialized variables and on `$` fields, newlines in `for` loops, and `^=` (power
+  assignment).
+- Fields and records: dynamic field numbers (`$(expr)`), `NF` tracking, `FS` parsing on empty
+  lines, `split()` return count and whitespace-regex handling, and `SUBSEP` handling.
+- Output: ternary expressions inside `print`, `print` argument handling, pipe output handling
+  and flushing, and `ORS` flushing.
+- Values and arrays: numeric string validation via `BigDecimal`, numeric detection when printing
+  fields, array iteration in insertion order, array deletion with numeric keys, and array
+  comparison.
+- `rand()` produces a deterministic sequence for a given `srand()` seed.
+
+[v3.3.05](https://github.com/jawkio/jawk/releases/tag/v3.3.05) (2025-04-03)
+----------
+
+- Java embedders only: packages renamed from `org.sentrysoftware.jawk` to `org.metricshub.jawk`;
+  no changes to AWK script behavior.
+
+[v3.3.04](https://github.com/jawkio/jawk/releases/tag/v3.3.04) (2025-02-13)
+----------
+
+- Fixed `sub()` with dollar references, and `sub()` / `gsub()` with `&` references in the
+  replacement string.
+
+[v3.3.03](https://github.com/jawkio/jawk/releases/tag/v3.3.03) (2024-08-29)
+----------
+
+- Fixed `gsub()` on array elements.
+- Removed the spurious SLF4J connection message from standard output.
+
+[v3.3.02](https://github.com/jawkio/jawk/releases/tag/v3.3.02) (2024-08-09)
+----------
+
+- Fixed operator associativity: most operations are left-associative, exponentiation (`^`) is
+  right-associative.
+
+[v3.3.01](https://github.com/jawkio/jawk/releases/tag/v3.3.01) (2024-08-09)
+----------
+
+- `substr()` no longer fails on out-of-range arguments.
+- Output redirection (`>`) is supported within `print` statements.
+- Fixed the argument order in extension function calls.
+
+[v3.3.00](https://github.com/jawkio/jawk/releases/tag/v3.3.00) (2024-02-04)
+----------
+
+- Fixed the evaluation order in string concatenation and in function argument lists.
+
+[v3.2.00](https://github.com/jawkio/jawk/releases/tag/v3.2.00) (2024-02-01)
+----------
+
+- `exit NN` returns the proper exit code from `BEGIN` and main rules.
+- Full support for the `ORS` special variable.
+- Full support for range patterns (`/start/, /end/`).
+- `NR` is updated even when the program has no main rule.
+
+[v3.1.02](https://github.com/jawkio/jawk/releases/tag/v3.1.02) (2024-01-18)
+----------
+
+- `!x` on an uninitialized variable now correctly evaluates to true.
+
+[v3.1.01](https://github.com/jawkio/jawk/releases/tag/v3.1.01) (2024-01-17)
+----------
+
+- Fixed escaping in regexp constants, notably octal sequences.
+- Improved syntax error messages.
+
+[v3.1.00](https://github.com/jawkio/jawk/releases/tag/v3.1.00) (2024-01-17)
+----------
+
+- Newlines are allowed after `&&`, `||`, `?`, `:`, and `,`.
+- Unary plus (`+a`) is supported.
+- Fixed precedence of ternary and concatenation expressions; parsing and lexing follow gawk
+  precedence rules for all operators.
+- Fixed parsing of escape sequences in regular expression constants.
+- Jawk runs on Java 8 and later.
+
+[v3.0.00](https://github.com/jawkio/jawk/releases/tag/v3.0.00) (2023-12-14)
+----------
+
+- `printf()` and `sprintf()` use the [Printf4J](https://github.com/metricshub/printf4j) library
+  for C-style formatting.
+- Java embedders: packages renamed from `org.jawk` to `org.sentrysoftware.jawk`; the library is
+  licensed under LGPL and released on Maven Central.
+
+[v2.1.00 (beta)](https://github.com/jawkio/jawk/releases/tag/v2.1.00-SNAPSHOT7) (2023)
+----------
+
+- Octal (`"\033"`) and hexadecimal (`"\x1B"`) escape sequences are supported in strings.
+
+See Also
+--------
+
+- [Compatibility and Compliance](compatibility.html)
+- [GitHub releases](https://github.com/jawkio/jawk/releases)

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -12,6 +12,13 @@ embedders. Releases that only contain internal refactoring, performance work, bu
 documentation changes are omitted. For the complete change lists, see the
 [GitHub releases](https://github.com/jawkio/jawk/releases).
 
+<!--
+Maintainers: every pull request that changes user-visible behavior must add a
+bullet under "Unreleased" below (see AGENTS.md). Do NOT rename that section by
+hand: the release workflow (.github/workflows/release.yml) stamps it with the
+released version automatically via .github/scripts/stamp-behavior-changes.sh.
+-->
+
 Unreleased
 ----------
 

--- a/src/site/markdown/compatibility.md.vm
+++ b/src/site/markdown/compatibility.md.vm
@@ -192,10 +192,6 @@ ${esc.h}${esc.h}${esc.h} Range patterns
 
 Range patterns (`begpat, endpat`) evaluate their two conditions lazily, as POSIX requires: the start condition is evaluated only while outside the range, and the end condition only once the range has started — including on the very record that starts it, so a range can begin and end on the same record. Conditions with side effects, such as `a++ == 2, a++ == 5`, therefore behave exactly as in gawk and One True Awk: each condition's side effects run only on the records where that condition is actually tested.
 
-${esc.h}${esc.h}${esc.h} Output conversion in `print`
-
-`print` writes string values verbatim, as POSIX requires: numeric-looking string constants such as `"0100"` or `"1e3"` are printed unchanged, and so are numeric strings that originate from input (fields, `getline`, `split()` pieces), which keep their original text. Only actual numbers are converted on output: integral values print as integers, and non-integral values are formatted with `OFMT`. `CONVFMT` governs number-to-string conversion everywhere else (concatenation, array subscripts, comparisons against strings), so `x = 1.2345; s = x ""; print s` prints the `CONVFMT`-converted string as-is, without reformatting it through `OFMT`.
-
 ${esc.h}${esc.h}${esc.h} Where Jawk follows gawk
 
 Jawk follows gawk in several places where gawk departs from historical AWK:
@@ -211,5 +207,6 @@ Jawk follows gawk in several places where gawk departs from historical AWK:
 See Also
 --------
 
+- [Behavior changes by version](behavior-changes.html)
 - [CLI options and tuple workflows](cli-reference.html)
 - [Java compilation and reuse APIs](java-compile.html)

--- a/src/site/markdown/compatibility.md.vm
+++ b/src/site/markdown/compatibility.md.vm
@@ -192,6 +192,10 @@ ${esc.h}${esc.h}${esc.h} Range patterns
 
 Range patterns (`begpat, endpat`) evaluate their two conditions lazily, as POSIX requires: the start condition is evaluated only while outside the range, and the end condition only once the range has started — including on the very record that starts it, so a range can begin and end on the same record. Conditions with side effects, such as `a++ == 2, a++ == 5`, therefore behave exactly as in gawk and One True Awk: each condition's side effects run only on the records where that condition is actually tested.
 
+${esc.h}${esc.h}${esc.h} Output conversion in `print`
+
+`print` writes string values verbatim, as POSIX requires: numeric-looking string constants such as `"0100"` or `"1e3"` are printed unchanged, and so are numeric strings that originate from input (fields, `getline`, `split()` pieces), which keep their original text. Only actual numbers are converted on output: integral values print as integers, and non-integral values are formatted with `OFMT`. `CONVFMT` governs number-to-string conversion everywhere else (concatenation, array subscripts, comparisons against strings), so `x = 1.2345; s = x ""; print s` prints the `CONVFMT`-converted string as-is, without reformatting it through `OFMT`.
+
 ${esc.h}${esc.h}${esc.h} Where Jawk follows gawk
 
 Jawk follows gawk in several places where gawk departs from historical AWK:

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -76,6 +76,7 @@
 
 		<menu name="Reference">
 			<item name="Compatibility and Compliance" href="compatibility.html" />
+			<item name="Behavior Changes" href="behavior-changes.html" />
 			<item name="Performance Benchmarks" href="benchmarks.html" />
 			<item name="Javadoc (API)" href="apidocs/index.html" />
 		</menu>

--- a/src/test/java/io/jawk/PosixConformanceTest.java
+++ b/src/test/java/io/jawk/PosixConformanceTest.java
@@ -365,6 +365,35 @@ public class PosixConformanceTest {
 	}
 
 	@Test
+	public void posix410aPrintStringConstantsVerbatim() throws Exception {
+		AwkTestSupport
+				.awkTest("POSIX 4.10a print outputs numeric-looking string constants verbatim")
+				.script("BEGIN { print \"0100\"; print \"1e3\"; print \"+0100\"; print \"-0500\"; print \"3.0\" }")
+				.expectLines("0100", "1e3", "+0100", "-0500", "3.0")
+				.runAndAssert();
+	}
+
+	@Test
+	public void posix410bPrintInputFieldsVerbatim() throws Exception {
+		AwkTestSupport
+				.awkTest("POSIX 4.10b print outputs numeric strings from input verbatim")
+				.script("{ print $1 }")
+				.stdin("0100\n1e3\n")
+				.expectLines("0100", "1e3")
+				.runAndAssert();
+	}
+
+	@Test
+	public void posix410cOfmtNotAppliedToStrings() throws Exception {
+		AwkTestSupport
+				.awkTest("POSIX 4.10c OFMT applies to numbers only, not to numeric strings")
+				.script("BEGIN{OFMT=\"%.2f\"} { print $1; print $1 + 0 }")
+				.stdin("3.14159\n")
+				.expectLines("3.14159", "3.14")
+				.runAndAssert();
+	}
+
+	@Test
 	public void posix411DivisionOperator() throws Exception {
 		AwkTestSupport
 				.awkTest("POSIX 4.11 division vs regex literal disambiguation")


### PR DESCRIPTION
Fixes #529.

## Problem

`print` numerically coerced any operand whose text parsed as a number, losing the original text:

```text
$ jawk 'BEGIN { print "0100"; print "1e3"; print "+0100"; print "-0500" }'
100
1000
100
-500
```

This affected not only string constants but also input-sourced values: `echo 0100 | jawk '{ print $1 }'` printed `100`, where gawk and POSIX AWK print `0100`.

## Root cause

`AwkSink.normalizePrintArgument()` converted every non-`Number` print operand whose `toString()` parsed as a `BigDecimal` into a `Double` before formatting, then applied OFMT. Per POSIX, `print` outputs string values (including strnums) unchanged; OFMT applies only when converting an actual number to a string.

## Fix

- Removed `normalizePrintArgument()`; `formatPrintArgument()` now formats real `Number`s with the integer/OFMT rules and prints everything else verbatim via `toString()`.
- Corrected `PosixIT.spec33OfmtVsConvfmt`, whose `1.24` expectation encoded the buggy double conversion (`s = x ""` → `"1.235"` via CONVFMT, then re-coerced and reformatted with OFMT). POSIX prints `s` verbatim: `1.235`.
- Added POSIX conformance tests: string constants verbatim, input fields verbatim, and OFMT applying to numbers only.

## Verification

- `mvn verify` passes: 639 unit tests, checkstyle/pmd/spotbugs clean.
- gawk compatibility suite: 5 tests newly pass (`test_fsfwfs`, `test_sortfor2`, `test_nasty2`, `test_numstr1`, `test_numsubstr`); no regressions vs `main` (`PosixIT.spec82NumericComparisonWithNumericStrings` already failed on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)