### PR TITLE
Expect correctly-rounded 1.234 in spec33OfmtVsConvfmt

### DIFF
--- a/src/it/java/io/jawk/posix/PosixIT.java
+++ b/src/it/java/io/jawk/posix/PosixIT.java
@@ -385,10 +385,13 @@ public class PosixIT {
 
 	@Test
 	public void spec33OfmtVsConvfmt() throws Exception {
+		// The double nearest 1.2345 is 1.23449999999999993..., strictly below the
+		// halfway point, so rounding the exact binary value to three decimals gives
+		// 1.234 (as gawk does), not the intuitive-looking 1.235.
 		AwkTestSupport
 				.awkTest("33. OFMT vs CONVFMT")
 				.script("BEGIN{OFMT=\"%.2f\"; CONVFMT=\"%.3f\"; x=1.2345; print x; s=x \"\"; print s}")
-				.expectLines("1.23", "1.235")
+				.expectLines("1.23", "1.234")
 				.runAndAssert();
 	}
 

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -65,9 +65,13 @@ released version automatically via .github/scripts/stamp-behavior-changes.sh.
       and fall back to `%g` notation for `%u`/`%o`/`%x`/`%X`.
     - NaN and infinities print as `nan`, `inf`, and `-inf` (previously Java's `NaN` /
       `Infinity`), in `print`, `printf`, and number-to-string conversions.
-    - `%e`, `%f`, and `%g` round halfway cases to even like the C library used by gawk
-      (`printf "%.0f", 2.5` prints `2`, previously `3`), and `%g` strips trailing zeros before
-      padding (previously only when no padding applied).
+    - `%e`, `%f`, and `%g` round the exact binary value of the double, with halfway cases to
+      even, like the C library used by gawk (`printf "%.0f", 2.5` prints `2`, previously `3`),
+      and `%g` strips trailing zeros before padding (previously only when no padding applied).
+      The same rounding applies to number-to-string conversions through `CONVFMT` and `OFMT`:
+      with `CONVFMT="%.3f"`, `1.2345 ""` is `1.234` (previously `1.235`, from rounding the
+      shortest decimal representation instead of the exact binary value, which is slightly
+      below the halfway point) ([#546](https://github.com/jawkio/jawk/issues/546)).
     - `printf` with too few arguments is now a fatal error, as in gawk (previously the leftover
       specifiers were printed verbatim).
     - Unknown conversion specifiers (including `%n`, which Printf4J turned into a newline, and


### PR DESCRIPTION
Fixes #546.

`PosixIT.spec33OfmtVsConvfmt` pinned `1.235` for `CONVFMT="%.3f"` applied to `1.2345`. That output came from the pre-#543 Printf4J path, which rounded the *shortest decimal representation* of the double (`"1.2345"`) with HALF_UP. The double nearest `1.2345` is `1.2344999999999999307...`, strictly below the halfway point, so any correct rounding of the actual value gives `1.234` — which is what gawk prints and what Jawk produces since #543.

Changes:

- Update the expectation to `1.23` / `1.234`, with a comment explaining why `1.234` is correct despite `1.235` looking more intuitive.
- Extend the existing #528/#543 rounding bullet in `behavior-changes.md` to also cover the number-to-string conversion surface (`CONVFMT`/`OFMT`), since the previously documented example only mentioned `printf`, and link #546.

Verified with `mvn verify -Dit.test=PosixIT#spec33OfmtVsConvfmt` (passes) and a full `mvn verify` (BUILD SUCCESS; the remaining failsafe compatibility failures are pre-existing on `main` and untouched by this change — in particular `spec82NumericComparisonWithNumericStrings`, confirmed failing on `main` at e653a5e, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)