### PR TITLE
Fix spec82 expectation: string constants compare as strings

### DIFF
--- a/src/it/java/io/jawk/posix/PosixIT.java
+++ b/src/it/java/io/jawk/posix/PosixIT.java
@@ -859,7 +859,7 @@ public class PosixIT {
 		AwkTestSupport
 				.awkTest("82. Numeric comparison with numeric strings")
 				.script("BEGIN{print (10<\"2\")?\"Y\":\"N\"; print (10<(\" 2\"))?\"Y\":\"N\"}")
-				.expectLines("N", "N")
+				.expectLines("Y", "N")
 				.runAndAssert();
 	}
 


### PR DESCRIPTION
Fixes #549

`PosixIT#spec82NumericComparisonWithNumericStrings` expected `N` / `N` for

```awk
BEGIN{print (10<"2")?"Y":"N"; print (10<(" 2"))?"Y":"N"}
```

but per POSIX the numeric-string comparison rules apply only to values derived from input (fields, `getline`, `ARGV`, `ENVIRON`, ...), never to string constants. Both comparisons are therefore string comparisons:

- `10 < "2"` → `"10" < "2"` → true → `Y`
- `10 < " 2"` → `"10" < " 2"` → `'1'` (0x31) > `' '` (0x20) → false → `N`

gawk 5.0 prints `Y` / `N` in both default and `--posix` mode, and Jawk already agrees, so this only corrects the test expectation from `N`/`N` to `Y`/`N`. No runtime change, hence no behavior-changes entry.

Verified with `mvn verify "-Dit.test=PosixIT#spec82NumericComparisonWithNumericStrings" "-Dtest=none" "-Dsurefire.failIfNoSpecifiedTests=false"`: 1 test run, 0 failures (confirmed in the failsafe report, not just the build result), checkstyle/pmd/spotbugs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
