### PR TITLE
Convert array subscripts with CONVFMT when the element is created

### DIFF
--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -25,7 +25,7 @@ package io.jawk.backend;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.math.BigInteger;
+import java.math.BigDecimal;
 import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.Arrays;
@@ -3692,32 +3692,45 @@ public class AVM implements VariableManager, Closeable {
 
 	/**
 	 * Converts a single-dimension subscript to the key form the associative
-	 * arrays store. Integral numbers pass through unchanged — recognized by
-	 * type for the integer classes ({@code Long}, {@code Integer},
-	 * {@code Short}, {@code Byte}, {@code BigInteger}, so no value is ever
-	 * misjudged through {@code double} projection), and by value for the
-	 * floating-point classes. The array implementations canonicalize them to
-	 * {@code Long} (skipping the string round-trip keeps integer-indexed
-	 * loops fast), and Java callers' injected plain {@code Map} variables
-	 * keep their exact key semantics. Every non-integral number (a computed
-	 * {@code Double}, or a {@code Float}/{@code BigDecimal}/... returned by
-	 * an extension or bound by a Java caller) and every non-numeric scalar
-	 * is converted to a string with the CONVFMT currently in effect, fixing
-	 * the key from that point on.
+	 * arrays store. Numbers whose value is integral and fits a signed 64-bit
+	 * integer pass through unchanged: the array implementations canonicalize
+	 * them to {@code Long} (skipping the string round-trip keeps
+	 * integer-indexed loops fast), and Java callers' injected plain
+	 * {@code Map} variables keep their exact key semantics. Every other
+	 * number (a non-integral or out-of-range {@code Double}, or a
+	 * {@code Float}/{@code BigDecimal}/... returned by an extension or bound
+	 * by a Java caller) and every non-numeric scalar is converted to a
+	 * string with the CONVFMT currently in effect, fixing the key from that
+	 * point on. Integrality is tested by type for the integer classes and by
+	 * exact decimal value for everything else, so no boundary value is ever
+	 * misjudged through {@code double} projection.
 	 */
 	private Object toSubscriptKey(Object value) {
-		if (value instanceof Long
-				|| value instanceof Integer
-				|| value instanceof Short
-				|| value instanceof Byte
-				|| value instanceof BigInteger) {
+		if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte) {
 			return value;
 		}
-		if (value instanceof Number && JRT.toScalarNumber(((Number) value).doubleValue()) instanceof Long) {
-			return value;
+		if (value instanceof Double) {
+			return JRT.toScalarNumber(((Double) value).doubleValue()) instanceof Long ? value : jrt.toAwkString(value);
+		}
+		if (value instanceof Number) {
+			try {
+				BigDecimal decimal = new BigDecimal(value.toString());
+				if (decimal.stripTrailingZeros().scale() <= 0
+						&& decimal.compareTo(MIN_LONG_SUBSCRIPT) >= 0
+						&& decimal.compareTo(MAX_LONG_SUBSCRIPT) <= 0) {
+					return value;
+				}
+			} catch (NumberFormatException e) { // NOPMD - EmptyCatchBlock: NaN/infinity converts as a string
+			}
 		}
 		return jrt.toAwkString(value);
 	}
+
+	/** Smallest subscript value that {@link #toSubscriptKey} passes through as a number. */
+	private static final BigDecimal MIN_LONG_SUBSCRIPT = BigDecimal.valueOf(Long.MIN_VALUE);
+
+	/** Largest subscript value that {@link #toSubscriptKey} passes through as a number. */
+	private static final BigDecimal MAX_LONG_SUBSCRIPT = BigDecimal.valueOf(Long.MAX_VALUE);
 
 	private long beforeProfiledTuple(Tuple tuple, Opcode opcode) {
 		long now = System.nanoTime();

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -3682,19 +3682,24 @@ public class AVM implements VariableManager, Closeable {
 
 	/**
 	 * Converts a single-dimension subscript to the key form the associative
-	 * arrays store. Integral numbers of any {@code Number} type (JSR-223
-	 * callers can bind any of them) pass through unchanged: the array
-	 * implementations canonicalize them to {@code Long}, so skipping the
-	 * string round-trip keeps integer-indexed loops fast, and injected plain
-	 * {@code Map} variables keep their exact key semantics. Every other
-	 * scalar is converted to a string with the CONVFMT currently in effect,
-	 * fixing the key from that point on.
+	 * arrays store. A non-integral {@code Double} — the only floating-point
+	 * type AWK code can produce — is converted to a string with the CONVFMT
+	 * currently in effect, fixing the key from that point on, and so is any
+	 * non-numeric scalar. Every other {@code Number} passes through
+	 * unchanged: integral values are canonicalized to {@code Long} by the
+	 * array implementations (skipping the string round-trip keeps
+	 * integer-indexed loops fast), and the remaining {@code Number} types
+	 * can only be bound by Java callers, whose injected plain {@code Map}
+	 * variables keep their exact key semantics.
 	 */
 	private Object toSubscriptKey(Object value) {
-		if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte) {
+		if (value instanceof Long || value instanceof Integer) {
 			return value;
 		}
-		if (value instanceof Number && JRT.toScalarNumber(((Number) value).doubleValue()) instanceof Long) {
+		if (value instanceof Double) {
+			return JRT.toScalarNumber(((Double) value).doubleValue()) instanceof Long ? value : jrt.toAwkString(value);
+		}
+		if (value instanceof Number) {
 			return value;
 		}
 		return jrt.toAwkString(value);

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -25,6 +25,7 @@ package io.jawk.backend;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.math.BigInteger;
 import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.Arrays;
@@ -2358,6 +2359,15 @@ public class AVM implements VariableManager, Closeable {
 					position.next();
 					break;
 				}
+				case APPLY_SUBSEP_UNDER_TOP: {
+					// stack[0] = value to keep on top (the "in" array operand)
+					// stack[1..count] = array indices to convert
+					Object top = pop();
+					execApplySubsep((CountTuple) tuple);
+					push(top);
+					position.next();
+					break;
+				}
 				case DELETE_ARRAY_ELEMENT: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
@@ -3682,24 +3692,28 @@ public class AVM implements VariableManager, Closeable {
 
 	/**
 	 * Converts a single-dimension subscript to the key form the associative
-	 * arrays store. A non-integral {@code Double} — the only floating-point
-	 * type AWK code can produce — is converted to a string with the CONVFMT
-	 * currently in effect, fixing the key from that point on, and so is any
-	 * non-numeric scalar. Every other {@code Number} passes through
-	 * unchanged: integral values are canonicalized to {@code Long} by the
-	 * array implementations (skipping the string round-trip keeps
-	 * integer-indexed loops fast), and the remaining {@code Number} types
-	 * can only be bound by Java callers, whose injected plain {@code Map}
-	 * variables keep their exact key semantics.
+	 * arrays store. Integral numbers pass through unchanged — recognized by
+	 * type for the integer classes ({@code Long}, {@code Integer},
+	 * {@code Short}, {@code Byte}, {@code BigInteger}, so no value is ever
+	 * misjudged through {@code double} projection), and by value for the
+	 * floating-point classes. The array implementations canonicalize them to
+	 * {@code Long} (skipping the string round-trip keeps integer-indexed
+	 * loops fast), and Java callers' injected plain {@code Map} variables
+	 * keep their exact key semantics. Every non-integral number (a computed
+	 * {@code Double}, or a {@code Float}/{@code BigDecimal}/... returned by
+	 * an extension or bound by a Java caller) and every non-numeric scalar
+	 * is converted to a string with the CONVFMT currently in effect, fixing
+	 * the key from that point on.
 	 */
 	private Object toSubscriptKey(Object value) {
-		if (value instanceof Long || value instanceof Integer) {
+		if (value instanceof Long
+				|| value instanceof Integer
+				|| value instanceof Short
+				|| value instanceof Byte
+				|| value instanceof BigInteger) {
 			return value;
 		}
-		if (value instanceof Double) {
-			return JRT.toScalarNumber(((Double) value).doubleValue()) instanceof Long ? value : jrt.toAwkString(value);
-		}
-		if (value instanceof Number) {
+		if (value instanceof Number && JRT.toScalarNumber(((Number) value).doubleValue()) instanceof Long) {
 			return value;
 		}
 		return jrt.toAwkString(value);

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -3663,7 +3663,7 @@ public class AVM implements VariableManager, Closeable {
 		if (count == 1) {
 			Object value = pop();
 			checkScalar(value);
-			push(jrt.toAwkString(value));
+			push(toSubscriptKey(value));
 			return;
 		}
 		StringBuilder sb = new StringBuilder();
@@ -3678,6 +3678,27 @@ public class AVM implements VariableManager, Closeable {
 			sb.insert(0, jrt.toAwkString(value));
 		}
 		push(sb.toString());
+	}
+
+	/**
+	 * Converts a single-dimension subscript to the key form the associative
+	 * arrays store. Integral numbers are kept as numbers: the array
+	 * implementations canonicalize them to {@code Long} anyway, and skipping
+	 * the string round-trip keeps integer-indexed loops fast. Every other
+	 * scalar is converted to a string with the CONVFMT currently in effect,
+	 * fixing the key from that point on.
+	 */
+	private Object toSubscriptKey(Object value) {
+		if (value instanceof Long || value instanceof Integer) {
+			return value;
+		}
+		if (value instanceof Double) {
+			Object scalar = JRT.toScalarNumber((Double) value);
+			if (scalar instanceof Long) {
+				return scalar;
+			}
+		}
+		return jrt.toAwkString(value);
 	}
 
 	private long beforeProfiledTuple(Tuple tuple, Opcode opcode) {

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -3679,15 +3679,25 @@ public class AVM implements VariableManager, Closeable {
 		StringBuilder sb = new StringBuilder();
 		Object value = pop();
 		checkScalar(value);
-		sb.append(jrt.toAwkString(value));
+		sb.append(toSubscriptComponentString(value));
 		String subsep = jrt.toAwkString(jrt.getSUBSEPVar());
 		for (int i = 1; i < count; i++) {
 			sb.insert(0, subsep);
 			value = pop();
 			checkScalar(value);
-			sb.insert(0, jrt.toAwkString(value));
+			sb.insert(0, toSubscriptComponentString(value));
 		}
 		push(sb.toString());
+	}
+
+	/**
+	 * Converts one component of a multi-dimensional subscript to the string
+	 * joined with SUBSEP, applying the same rules as {@link #toSubscriptKey}
+	 * so beyond-range integral values keep their exact digits.
+	 */
+	private String toSubscriptComponentString(Object value) {
+		Object key = toSubscriptKey(value);
+		return key instanceof String ? (String) key : jrt.toAwkString(key);
 	}
 
 	/**

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -3715,10 +3715,14 @@ public class AVM implements VariableManager, Closeable {
 		if (value instanceof Number) {
 			try {
 				BigDecimal decimal = new BigDecimal(value.toString());
-				if (decimal.stripTrailingZeros().scale() <= 0
-						&& decimal.compareTo(MIN_LONG_SUBSCRIPT) >= 0
-						&& decimal.compareTo(MAX_LONG_SUBSCRIPT) <= 0) {
-					return value;
+				if (decimal.stripTrailingZeros().scale() <= 0) {
+					if (decimal.compareTo(MIN_LONG_SUBSCRIPT) >= 0 && decimal.compareTo(MAX_LONG_SUBSCRIPT) <= 0) {
+						return value;
+					}
+					// An integral value beyond the signed 64-bit range keys as
+					// its exact digits, without a double round-trip that would
+					// collide nearby values.
+					return decimal.toBigInteger().toString();
 				}
 			} catch (NumberFormatException e) { // NOPMD - EmptyCatchBlock: NaN/infinity converts as a string
 			}

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -25,7 +25,6 @@ package io.jawk.backend;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.math.BigDecimal;
 import java.util.AbstractSet;
 import java.util.Iterator;
 import java.util.Arrays;
@@ -3673,78 +3672,27 @@ public class AVM implements VariableManager, Closeable {
 		if (count == 1) {
 			Object value = pop();
 			checkScalar(value);
-			push(toSubscriptKey(value));
+			// An integral number is already in the form the array
+			// implementations canonicalize to a Long key, so it skips the
+			// CONVFMT string round-trip; every other scalar converts to a
+			// string with the CONVFMT currently in effect, fixing the key
+			// from that point on.
+			push(AssocArray.isIntegralNumberKey(value) ? value : jrt.toAwkString(value));
 			return;
 		}
 		StringBuilder sb = new StringBuilder();
 		Object value = pop();
 		checkScalar(value);
-		sb.append(toSubscriptComponentString(value));
+		sb.append(jrt.toAwkString(value));
 		String subsep = jrt.toAwkString(jrt.getSUBSEPVar());
 		for (int i = 1; i < count; i++) {
 			sb.insert(0, subsep);
 			value = pop();
 			checkScalar(value);
-			sb.insert(0, toSubscriptComponentString(value));
+			sb.insert(0, jrt.toAwkString(value));
 		}
 		push(sb.toString());
 	}
-
-	/**
-	 * Converts one component of a multi-dimensional subscript to the string
-	 * joined with SUBSEP, applying the same rules as {@link #toSubscriptKey}
-	 * so beyond-range integral values keep their exact digits.
-	 */
-	private String toSubscriptComponentString(Object value) {
-		Object key = toSubscriptKey(value);
-		return key instanceof String ? (String) key : jrt.toAwkString(key);
-	}
-
-	/**
-	 * Converts a single-dimension subscript to the key form the associative
-	 * arrays store. Numbers whose value is integral and fits a signed 64-bit
-	 * integer pass through unchanged: the array implementations canonicalize
-	 * them to {@code Long} (skipping the string round-trip keeps
-	 * integer-indexed loops fast), and Java callers' injected plain
-	 * {@code Map} variables keep their exact key semantics. Every other
-	 * number (a non-integral or out-of-range {@code Double}, or a
-	 * {@code Float}/{@code BigDecimal}/... returned by an extension or bound
-	 * by a Java caller) and every non-numeric scalar is converted to a
-	 * string with the CONVFMT currently in effect, fixing the key from that
-	 * point on. Integrality is tested by type for the integer classes and by
-	 * exact decimal value for everything else, so no boundary value is ever
-	 * misjudged through {@code double} projection.
-	 */
-	private Object toSubscriptKey(Object value) {
-		if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte) {
-			return value;
-		}
-		if (value instanceof Double) {
-			return JRT.toScalarNumber(((Double) value).doubleValue()) instanceof Long ? value : jrt.toAwkString(value);
-		}
-		if (value instanceof Number) {
-			try {
-				BigDecimal decimal = new BigDecimal(value.toString());
-				if (decimal.stripTrailingZeros().scale() <= 0) {
-					if (decimal.compareTo(MIN_LONG_SUBSCRIPT) >= 0 && decimal.compareTo(MAX_LONG_SUBSCRIPT) <= 0) {
-						return value;
-					}
-					// An integral value beyond the signed 64-bit range keys as
-					// its exact digits, without a double round-trip that would
-					// collide nearby values.
-					return decimal.toBigInteger().toString();
-				}
-			} catch (NumberFormatException e) { // NOPMD - EmptyCatchBlock: NaN/infinity converts as a string
-			}
-		}
-		return jrt.toAwkString(value);
-	}
-
-	/** Smallest subscript value that {@link #toSubscriptKey} passes through as a number. */
-	private static final BigDecimal MIN_LONG_SUBSCRIPT = BigDecimal.valueOf(Long.MIN_VALUE);
-
-	/** Largest subscript value that {@link #toSubscriptKey} passes through as a number. */
-	private static final BigDecimal MAX_LONG_SUBSCRIPT = BigDecimal.valueOf(Long.MAX_VALUE);
 
 	private long beforeProfiledTuple(Tuple tuple, Opcode opcode) {
 		long now = System.nanoTime();

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -3682,9 +3682,10 @@ public class AVM implements VariableManager, Closeable {
 
 	/**
 	 * Converts a single-dimension subscript to the key form the associative
-	 * arrays store. Integral numbers are kept as numbers: the array
-	 * implementations canonicalize them to {@code Long} anyway, and skipping
-	 * the string round-trip keeps integer-indexed loops fast. Every other
+	 * arrays store. Integral numbers pass through unchanged: the array
+	 * implementations canonicalize them to {@code Long}, so skipping the
+	 * string round-trip keeps integer-indexed loops fast, and injected plain
+	 * {@code Map} variables keep their exact key semantics. Every other
 	 * scalar is converted to a string with the CONVFMT currently in effect,
 	 * fixing the key from that point on.
 	 */
@@ -3692,11 +3693,8 @@ public class AVM implements VariableManager, Closeable {
 		if (value instanceof Long || value instanceof Integer) {
 			return value;
 		}
-		if (value instanceof Double) {
-			Object scalar = JRT.toScalarNumber((Double) value);
-			if (scalar instanceof Long) {
-				return scalar;
-			}
+		if (value instanceof Double && JRT.toScalarNumber((Double) value) instanceof Long) {
+			return value;
 		}
 		return jrt.toAwkString(value);
 	}

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -3682,7 +3682,8 @@ public class AVM implements VariableManager, Closeable {
 
 	/**
 	 * Converts a single-dimension subscript to the key form the associative
-	 * arrays store. Integral numbers pass through unchanged: the array
+	 * arrays store. Integral numbers of any {@code Number} type (JSR-223
+	 * callers can bind any of them) pass through unchanged: the array
 	 * implementations canonicalize them to {@code Long}, so skipping the
 	 * string round-trip keeps integer-indexed loops fast, and injected plain
 	 * {@code Map} variables keep their exact key semantics. Every other
@@ -3690,10 +3691,10 @@ public class AVM implements VariableManager, Closeable {
 	 * fixing the key from that point on.
 	 */
 	private Object toSubscriptKey(Object value) {
-		if (value instanceof Long || value instanceof Integer) {
+		if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof Byte) {
 			return value;
 		}
-		if (value instanceof Double && JRT.toScalarNumber((Double) value) instanceof Long) {
+		if (value instanceof Number && JRT.toScalarNumber(((Number) value).doubleValue()) instanceof Long) {
 			return value;
 		}
 		return jrt.toAwkString(value);

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -4216,13 +4216,26 @@ public class AwkParser {
 				throw new SemanticException("Expecting an array for rhs of IN. Got an expression.");
 			}
 
-			getAst1().populateTuples(tuples);
-			if (!(getAst1() instanceof ArrayIndexAst)) {
-				// A bare scalar key ("x in a") is converted with the current
-				// CONVFMT, just like a bracketed subscript would be.
+			AST keyAst = getAst1();
+			boolean singleKey = !(keyAst instanceof ArrayIndexAst) || keyAst.getAst2() == null;
+			if (singleKey) {
+				// A single key is converted with the CONVFMT in effect when the
+				// operator executes, i.e. after the array operand has been
+				// evaluated (it may have side effects), just like gawk: evaluate
+				// the raw key, evaluate the array operand, then convert the key
+				// underneath it.
+				AST rawKeyAst = keyAst instanceof ArrayIndexAst ? keyAst.getAst1() : keyAst;
+				rawKeyAst.populateTuples(tuples);
+				populateArrayOperandTuples(getAst2(), tuples, false, "Expecting an array for rhs of IN. Got a scalar.");
+				tuples.swap();
 				tuples.applySubsep(1);
+				tuples.swap();
+			} else {
+				// A multi-dimensional key joins its components with SUBSEP as it
+				// is built, before the array operand is evaluated.
+				keyAst.populateTuples(tuples);
+				populateArrayOperandTuples(getAst2(), tuples, false, "Expecting an array for rhs of IN. Got a scalar.");
 			}
-			populateArrayOperandTuples(getAst2(), tuples, false, "Expecting an array for rhs of IN. Got a scalar.");
 			tuples.isIn();
 
 			popSourceLineNumber(tuples);

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -1613,10 +1613,11 @@ public class AwkParser {
 			lexer();
 			optNewline();
 			AST rest = ASSIGNMENT_EXPRESSION(null, allowComparison, allowInKeyword, true);
+			int lineNo = currentSourceLineNumber();
 			if (rest instanceof ArrayIndexAst) {
-				return new ArrayIndexAst(result, rest);
+				return new ArrayIndexAst(lineNo, result, rest);
 			}
-			return new ArrayIndexAst(result, new ArrayIndexAst(rest, null));
+			return new ArrayIndexAst(lineNo, result, new ArrayIndexAst(lineNo, rest, null));
 		}
 		return result;
 	}
@@ -2091,13 +2092,17 @@ public class AwkParser {
 
 	// ARRAY_INDEX : ASSIGNMENT_EXPRESSION [, ARRAY_INDEX]
 	AST ARRAY_INDEX(boolean allowComparison, boolean allowInKeyword) throws IOException {
+		// Capture the line before parsing the expression: the expression AST can
+		// be a shared identifier node carrying its first occurrence's line, and
+		// by the end of the expression the lexer may have read past the line.
+		int lineNo = currentSourceLineNumber();
 		AST exprAst = ASSIGNMENT_EXPRESSION(null, allowComparison, allowInKeyword, false);
 		if (token == Token.COMMA) {
 			optNewline();
 			lexer();
-			return new ArrayIndexAst(exprAst, ARRAY_INDEX(allowComparison, allowInKeyword));
+			return new ArrayIndexAst(lineNo, exprAst, ARRAY_INDEX(allowComparison, allowInKeyword));
 		} else {
-			return new ArrayIndexAst(exprAst, null);
+			return new ArrayIndexAst(lineNo, exprAst, null);
 		}
 	}
 
@@ -2447,7 +2452,7 @@ public class AwkParser {
 	// it turned out to be, when the parenthesized group is followed by "in"
 	private AST toMultidimIndex(FunctionCallParamListAst list) {
 		AST rest = list.getAst2() == null ? null : toMultidimIndex((FunctionCallParamListAst) list.getAst2());
-		return new ArrayIndexAst(list.getAst1(), rest);
+		return new ArrayIndexAst(list.getLineNo(), list.getAst1(), rest);
 	}
 
 	AST PRINT_STATEMENT() throws IOException {
@@ -4473,12 +4478,10 @@ public class AwkParser {
 
 	private final class ArrayIndexAst extends ScalarExpressionAst {
 
-		private ArrayIndexAst(AST exprAst, AST next) {
-			// Anchor to the first subscript expression's line: by the time this
-			// node is built the lexer may have read past the end of the line,
-			// and the APPLY_SUBSEP tuple must report errors where the subscript
-			// starts.
-			super(exprAst.getLineNo(), exprAst, next);
+		private ArrayIndexAst(int lineNo, AST exprAst, AST next) {
+			// The line is captured where the subscript expression starts, so
+			// the APPLY_SUBSEP tuple reports errors there.
+			super(lineNo, exprAst, next);
 		}
 
 		@Override

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -4217,6 +4217,11 @@ public class AwkParser {
 			}
 
 			getAst1().populateTuples(tuples);
+			if (!(getAst1() instanceof ArrayIndexAst)) {
+				// A bare scalar key ("x in a") is converted with the current
+				// CONVFMT, just like a bracketed subscript would be.
+				tuples.applySubsep(1);
+			}
 			populateArrayOperandTuples(getAst2(), tuples, false, "Expecting an array for rhs of IN. Got a scalar.");
 			tuples.isIn();
 
@@ -4456,7 +4461,11 @@ public class AwkParser {
 	private final class ArrayIndexAst extends ScalarExpressionAst {
 
 		private ArrayIndexAst(AST exprAst, AST next) {
-			super(exprAst, next);
+			// Anchor to the first subscript expression's line: by the time this
+			// node is built the lexer may have read past the end of the line,
+			// and the APPLY_SUBSEP tuple must report errors where the subscript
+			// starts.
+			super(exprAst.getLineNo(), exprAst, next);
 		}
 
 		@Override
@@ -4469,9 +4478,10 @@ public class AwkParser {
 				++cnt;
 				ptr = ptr.getAst2();
 			}
-			if (cnt > 1) {
-				tuples.applySubsep(cnt);
-			}
+			// Convert the subscript to its string form now, with the CONVFMT in
+			// effect at this point of the execution: a later CONVFMT change must
+			// not retroactively alter existing keys.
+			tuples.applySubsep(cnt);
 			popSourceLineNumber(tuples);
 			return 1;
 		}

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -1583,6 +1583,10 @@ public class AwkParser {
 			boolean allowInKeyword,
 			boolean allowMultidimIndices)
 			throws IOException {
+		// Captured before parsing: if the expression turns out to be the first
+		// component of a multi-dimensional subscript group, the group's line is
+		// where this component starts.
+		int startLineNo = currentSourceLineNumber();
 		AST ternaryExpression = TERNARY_EXPRESSION(left, allowComparison, allowInKeyword, allowMultidimIndices);
 		AST result = ternaryExpression;
 		if (token == Token.EQUALS
@@ -1612,12 +1616,12 @@ public class AwkParser {
 		if (allowMultidimIndices && token == Token.COMMA) {
 			lexer();
 			optNewline();
+			int restLineNo = currentSourceLineNumber();
 			AST rest = ASSIGNMENT_EXPRESSION(null, allowComparison, allowInKeyword, true);
-			int lineNo = currentSourceLineNumber();
 			if (rest instanceof ArrayIndexAst) {
-				return new ArrayIndexAst(lineNo, result, rest);
+				return new ArrayIndexAst(startLineNo, result, rest);
 			}
-			return new ArrayIndexAst(lineNo, result, new ArrayIndexAst(lineNo, rest, null));
+			return new ArrayIndexAst(startLineNo, result, new ArrayIndexAst(restLineNo, rest, null));
 		}
 		return result;
 	}
@@ -4221,25 +4225,23 @@ public class AwkParser {
 				throw new SemanticException("Expecting an array for rhs of IN. Got an expression.");
 			}
 
+			// The key is joined and converted with the SUBSEP and CONVFMT in
+			// effect when the operator executes, i.e. after the array operand
+			// has been evaluated (it may have side effects), just like gawk.
 			AST keyAst = getAst1();
-			boolean singleKey = !(keyAst instanceof ArrayIndexAst) || keyAst.getAst2() == null;
-			if (singleKey) {
-				// A single key is converted with the CONVFMT in effect when the
-				// operator executes, i.e. after the array operand has been
-				// evaluated (it may have side effects), just like gawk: evaluate
-				// the raw key, evaluate the array operand, then convert the key
-				// underneath it.
-				AST rawKeyAst = keyAst instanceof ArrayIndexAst ? keyAst.getAst1() : keyAst;
-				rawKeyAst.populateTuples(tuples);
+			if (keyAst instanceof ArrayIndexAst) {
+				ArrayIndexAst indexAst = (ArrayIndexAst) keyAst;
+				int count = indexAst.populateComponentTuples(tuples);
 				populateArrayOperandTuples(getAst2(), tuples, false, "Expecting an array for rhs of IN. Got a scalar.");
-				tuples.swap();
-				tuples.applySubsep(1);
-				tuples.swap();
+				// Errors while converting the key report where the subscript
+				// starts.
+				indexAst.pushSourceLineNumber(tuples);
+				tuples.applySubsepUnderTop(count);
+				indexAst.popSourceLineNumber(tuples);
 			} else {
-				// A multi-dimensional key joins its components with SUBSEP as it
-				// is built, before the array operand is evaluated.
 				keyAst.populateTuples(tuples);
 				populateArrayOperandTuples(getAst2(), tuples, false, "Expecting an array for rhs of IN. Got a scalar.");
+				tuples.applySubsepUnderTop(1);
 			}
 			tuples.isIn();
 
@@ -4487,6 +4489,21 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
+			int cnt = populateComponentTuples(tuples);
+			// Convert the subscript to its string form now, with the CONVFMT in
+			// effect at this point of the execution: a later CONVFMT change must
+			// not retroactively alter existing keys.
+			tuples.applySubsep(cnt);
+			popSourceLineNumber(tuples);
+			return 1;
+		}
+
+		/**
+		 * Evaluates the raw subscript components without joining or converting
+		 * them, and returns how many were pushed. The "in" operator uses this
+		 * to delay the conversion until its array operand has been evaluated.
+		 */
+		private int populateComponentTuples(AwkTuples tuples) {
 			AST ptr = this;
 			int cnt = 0;
 			while (ptr != null) {
@@ -4494,12 +4511,7 @@ public class AwkParser {
 				++cnt;
 				ptr = ptr.getAst2();
 			}
-			// Convert the subscript to its string form now, with the CONVFMT in
-			// effect at this point of the execution: a later CONVFMT change must
-			// not retroactively alter existing keys.
-			tuples.applySubsep(cnt);
-			popSourceLineNumber(tuples);
-			return 1;
+			return cnt;
 		}
 	}
 

--- a/src/main/java/io/jawk/frontend/AwkParser.java
+++ b/src/main/java/io/jawk/frontend/AwkParser.java
@@ -1559,6 +1559,11 @@ public class AwkParser {
 	 *        – false ⇒ disallow “in”
 	 */
 	AST EXPRESSION_LIST(boolean allowComparisons, boolean allowInKeyword) throws IOException {
+		// Captured before parsing: the list node's line is where its first
+		// expression starts, so a parenthesized group rebuilt into a
+		// multi-dimensional subscript reports errors there.
+		int lineNo = currentSourceLineNumber();
+
 		// 1) Parse exactly one assignment expression.
 		// Passing `allowComparisons` will decide if ‘>’/’<’ become comparisons or redirectors.
 		AST expr = ASSIGNMENT_EXPRESSION(null, allowComparisons, allowInKeyword, /* allowMultidim= */ false);
@@ -1570,11 +1575,11 @@ public class AwkParser {
 			optNewline(); // allow newline after comma (AWK style)
 
 			AST rest = EXPRESSION_LIST(allowComparisons, allowInKeyword);
-			return new FunctionCallParamListAst(expr, rest);
+			return new FunctionCallParamListAst(lineNo, expr, rest);
 		}
 
 		// 3) No comma ⇒ this single expression is a one‐element list.
-		return new FunctionCallParamListAst(expr, null);
+		return new FunctionCallParamListAst(lineNo, expr, null);
 	}
 
 	private AST ASSIGNMENT_EXPRESSION(
@@ -5082,6 +5087,10 @@ public class AwkParser {
 
 		private FunctionCallParamListAst(AST expr, AST rest) {
 			super(expr, rest);
+		}
+
+		private FunctionCallParamListAst(int lineNo, AST expr, AST rest) {
+			super(lineNo, expr, rest);
 		}
 
 		@Override

--- a/src/main/java/io/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/io/jawk/intermediate/AwkTuples.java
@@ -50,7 +50,10 @@ import io.jawk.jrt.JRT;
  */
 public class AwkTuples implements Serializable {
 
-	private static final long serialVersionUID = 3L;
+	// Bumped to 4 when single-dimension subscripts started emitting
+	// APPLY_SUBSEP: older tuple streams lack the conversion and must be
+	// recompiled.
+	private static final long serialVersionUID = 4L;
 
 	/** Address manager */
 	private final AddressManager addressManager = new AddressManager();

--- a/src/main/java/io/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/io/jawk/intermediate/AwkTuples.java
@@ -1793,6 +1793,17 @@ public class AwkTuples implements Serializable {
 
 	/**
 	 * <p>
+	 * applySubsepUnderTop.
+	 * </p>
+	 *
+	 * @param count a int
+	 */
+	public void applySubsepUnderTop(int count) {
+		queue.add(new Tuple.CountTuple(Opcode.APPLY_SUBSEP_UNDER_TOP, count));
+	}
+
+	/**
+	 * <p>
 	 * deleteArrayElement.
 	 * </p>
 	 *

--- a/src/main/java/io/jawk/intermediate/Opcode.java
+++ b/src/main/java/io/jawk/intermediate/Opcode.java
@@ -1652,7 +1652,18 @@ public enum Opcode {
 	 * Stack before: ... <br>
 	 * Stack after: ...
 	 */
-	CONDITION_PAIR_LEAVE;
+	CONDITION_PAIR_LEAVE,
+
+	/**
+	 * Convert a list of array indices located under the top stack element to
+	 * their concatenated SUBSEP key, leaving the top element in place. Used by
+	 * the "in" operator, whose key must be converted with the CONVFMT and
+	 * SUBSEP in effect after the array operand has been evaluated.
+	 * <p>
+	 * Stack before: i1, i2, ..., in, top <br>
+	 * Stack after: "i1SUBSEPi2SUBSEP...in", top
+	 */
+	APPLY_SUBSEP_UNDER_TOP;
 
 	private static final Opcode[] VALUES = values();
 

--- a/src/main/java/io/jawk/jrt/AssocArray.java
+++ b/src/main/java/io/jawk/jrt/AssocArray.java
@@ -96,6 +96,25 @@ public interface AssocArray extends Map<Object, Object> {
 	}
 
 	/**
+	 * Returns whether a subscript value is an integral number that
+	 * {@link #normalizeKey(Object)} canonicalizes to the same {@code Long}
+	 * key as its AWK string form. Such a subscript can be used as a key
+	 * directly, without the CONVFMT string conversion that every other
+	 * scalar goes through: the resulting key is identical, and skipping the
+	 * string round-trip keeps integer-indexed loops fast.
+	 *
+	 * @param value the subscript value to examine
+	 * @return {@code true} if the value can be used as a key without string
+	 *         conversion
+	 */
+	static boolean isIntegralNumberKey(Object value) {
+		if (value instanceof Long || value instanceof Integer) {
+			return true;
+		}
+		return value instanceof Double && JRT.toScalarNumber((Double) value) instanceof Long;
+	}
+
+	/**
 	 * Attempts to parse the key as a {@code Long}.
 	 *
 	 * @param key the key to parse (must not be {@code null})

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -29,8 +29,11 @@ released version automatically via .github/scripts/stamp-behavior-changes.sh.
   `CONVFMT` change above, `(12.153 in test)` is `0` because the lookup key converts to `12`.
   Integer subscripts within the signed 64-bit range are unaffected, and integral subscripts
   beyond that range now key as their exact digits like gawk: `a[2^63]` creates the key
-  `9223372036854775808` (previously clamped to `9223372036854775807`)
-  ([#547](https://github.com/jawkio/jawk/issues/547)).
+  `9223372036854775808` (previously clamped to `9223372036854775807`). The "attempting to use
+  an array in a scalar context" error for an array used as a subscript is now raised when the
+  subscript is converted and reported on the line where the subscript starts (previously it was
+  raised by the operation consuming the subscript and reported on the line of the enclosing
+  array reference) ([#547](https://github.com/jawkio/jawk/issues/547)).
 - Numeric constants with exponents (`2e3`, `1.5E-2`, `.5e+1`, ...) are now lexed as single
   numbers, as POSIX requires: `print 2e3` prints `2000` (previously the lexer stopped before the
   exponent, so `2e3` parsed as `2` concatenated with the uninitialized variable `e3` and printed

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -20,6 +20,14 @@ released version automatically via .github/scripts/stamp-behavior-changes.sh.
 
 ## Unreleased
 
+- Array subscripts are now converted to their string key with the `CONVFMT` in effect at the
+  moment the subscript is used, as POSIX requires and gawk does. Previously a single-dimension
+  numeric subscript was stored as a number and converted lazily, so a later `CONVFMT` change
+  retroactively altered existing keys: `a = 12.153; test[a] = "hi"; CONVFMT = "%.0f"` now keeps
+  the key `12.153` when iterating with `for (i in test)` (previously the key became `12`). The
+  same conversion now also applies to the key of the `in` operator and `delete`, so after the
+  `CONVFMT` change above, `(12.153 in test)` is `0` because the lookup key converts to `12`.
+  Integer subscripts are unaffected ([#547](https://github.com/jawkio/jawk/issues/547)).
 - Numeric constants with exponents (`2e3`, `1.5E-2`, `.5e+1`, ...) are now lexed as single
   numbers, as POSIX requires: `print 2e3` prints `2000` (previously the lexer stopped before the
   exponent, so `2e3` parsed as `2` concatenated with the uninitialized variable `e3` and printed

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -27,7 +27,10 @@ released version automatically via .github/scripts/stamp-behavior-changes.sh.
   the key `12.153` when iterating with `for (i in test)` (previously the key became `12`). The
   same conversion now also applies to the key of the `in` operator and `delete`, so after the
   `CONVFMT` change above, `(12.153 in test)` is `0` because the lookup key converts to `12`.
-  Integer subscripts are unaffected ([#547](https://github.com/jawkio/jawk/issues/547)).
+  Integer subscripts within the signed 64-bit range are unaffected, and integral subscripts
+  beyond that range now key as their exact digits like gawk: `a[2^63]` creates the key
+  `9223372036854775808` (previously clamped to `9223372036854775807`)
+  ([#547](https://github.com/jawkio/jawk/issues/547)).
 - Numeric constants with exponents (`2e3`, `1.5E-2`, `.5e+1`, ...) are now lexed as single
   numbers, as POSIX requires: `print 2e3` prints `2000` (previously the lexer stopped before the
   exponent, so `2e3` parsed as `2` concatenated with the uninitialized variable `e3` and printed

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -24,6 +24,7 @@ package io.jawk;
 
 import static org.junit.Assert.*;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
@@ -365,18 +366,20 @@ public class AssocArrayTest {
 		data.put(Float.valueOf(2.0f), "two");
 		data.put(Short.valueOf((short) 3), "three");
 		data.put(BigInteger.valueOf(Long.MAX_VALUE), "big");
+		data.put(BigDecimal.valueOf(Long.MAX_VALUE), "bigdec");
 
 		AwkTestSupport
 				.awkTest("injected Map Number keys stay reachable with same-typed subscripts")
 				.script(
 						"BEGIN{ print arr[d], (d in arr), arr[f], (f in arr), arr[s], (s in arr),"
-								+ " arr[b], (b in arr) }")
+								+ " arr[b], (b in arr), arr[bd], (bd in arr) }")
 				.preassign("arr", data)
 				.preassign("d", Double.valueOf(1.0))
 				.preassign("f", Float.valueOf(2.0f))
 				.preassign("s", Short.valueOf((short) 3))
 				.preassign("b", BigInteger.valueOf(Long.MAX_VALUE))
-				.expectLines("one 1 two 1 three 1 big 1")
+				.preassign("bd", BigDecimal.valueOf(Long.MAX_VALUE))
+				.expectLines("one 1 two 1 three 1 big 1 bigdec 1")
 				.runAndAssert();
 	}
 

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -24,6 +24,7 @@ package io.jawk;
 
 import static org.junit.Assert.*;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -358,20 +359,24 @@ public class AssocArrayTest {
 	}
 
 	@Test
-	public void testInjectMapVariableKeepsIntegralNumberKeys() throws Exception {
+	public void testInjectMapVariableKeepsNumberKeys() throws Exception {
 		Map<Object, Object> data = new LinkedHashMap<>();
 		data.put(Double.valueOf(1.0), "one");
 		data.put(Float.valueOf(2.0f), "two");
 		data.put(Short.valueOf((short) 3), "three");
+		data.put(BigInteger.valueOf(Long.MAX_VALUE), "big");
 
 		AwkTestSupport
-				.awkTest("injected Map integral Number keys stay reachable with same-typed subscripts")
-				.script("BEGIN{ print arr[d], (d in arr), arr[f], (f in arr), arr[s], (s in arr) }")
+				.awkTest("injected Map Number keys stay reachable with same-typed subscripts")
+				.script(
+						"BEGIN{ print arr[d], (d in arr), arr[f], (f in arr), arr[s], (s in arr),"
+								+ " arr[b], (b in arr) }")
 				.preassign("arr", data)
 				.preassign("d", Double.valueOf(1.0))
 				.preassign("f", Float.valueOf(2.0f))
 				.preassign("s", Short.valueOf((short) 3))
-				.expectLines("one 1 two 1 three 1")
+				.preassign("b", BigInteger.valueOf(Long.MAX_VALUE))
+				.expectLines("one 1 two 1 three 1 big 1")
 				.runAndAssert();
 	}
 

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -389,10 +389,12 @@ public class AssocArrayTest {
 				.awkTest("arbitrary-precision integer subscripts key as their exact digits")
 				.script(
 						"BEGIN { a[n1] = 1; a[n2] = 2; print length(a),"
-								+ " (\"9223372036854775808\" in a), (\"9223372036854775809\" in a) }")
+								+ " (\"9223372036854775808\" in a), (\"9223372036854775809\" in a);"
+								+ " b[n1, 0] = 1; b[n2, 0] = 2; print length(b),"
+								+ " ((\"9223372036854775808\" SUBSEP \"0\") in b) }")
 				.preassign("n1", new BigInteger("9223372036854775808"))
 				.preassign("n2", new BigInteger("9223372036854775809"))
-				.expectLines("2 1 1")
+				.expectLines("2 1 1", "2 1")
 				.runAndAssert();
 	}
 

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -358,16 +358,20 @@ public class AssocArrayTest {
 	}
 
 	@Test
-	public void testInjectMapVariableKeepsIntegralDoubleKeys() throws Exception {
+	public void testInjectMapVariableKeepsIntegralNumberKeys() throws Exception {
 		Map<Object, Object> data = new LinkedHashMap<>();
 		data.put(Double.valueOf(1.0), "one");
+		data.put(Float.valueOf(2.0f), "two");
+		data.put(Short.valueOf((short) 3), "three");
 
 		AwkTestSupport
-				.awkTest("injected Map Double keys stay reachable with a Double subscript")
-				.script("BEGIN{ print arr[idx], (idx in arr) }")
+				.awkTest("injected Map integral Number keys stay reachable with same-typed subscripts")
+				.script("BEGIN{ print arr[d], (d in arr), arr[f], (f in arr), arr[s], (s in arr) }")
 				.preassign("arr", data)
-				.preassign("idx", Double.valueOf(1.0))
-				.expectLines("one 1")
+				.preassign("d", Double.valueOf(1.0))
+				.preassign("f", Float.valueOf(2.0f))
+				.preassign("s", Short.valueOf((short) 3))
+				.expectLines("one 1 two 1 three 1")
 				.runAndAssert();
 	}
 

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -358,6 +358,72 @@ public class AssocArrayTest {
 	}
 
 	@Test
+	public void testSingleDimensionSubscriptKeyFixedAtCreationTime() throws Exception {
+		AwkTestSupport
+				.awkTest("single-dimension subscript keeps its key after CONVFMT changes")
+				.script(
+						"BEGIN { a = 12.153; test[a] = \"hi\"; CONVFMT = \"%.0f\"; a = 5;"
+								+ " for (i in test) printf (\"test[%s] = %s\\n\", i, test[i]) }")
+				.expectLines("test[12.153] = hi")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testMultiDimensionSubscriptKeyFixedAtCreationTime() throws Exception {
+		AwkTestSupport
+				.awkTest("multi-dimensional subscript keeps its key after CONVFMT changes")
+				.script(
+						"BEGIN { test[1.5, 2.5] = \"hi\"; CONVFMT = \"%.0f\";"
+								+ " for (i in test) { split(i, parts, SUBSEP); print parts[1], parts[2] } }")
+				.expectLines("1.5 2.5")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testSubscriptKeyUsesConvfmtInEffectAtCreation() throws Exception {
+		AwkTestSupport
+				.awkTest("subscript key is built with the CONVFMT in effect at creation")
+				.script(
+						"BEGIN { CONVFMT = \"%.2f\"; a[3.14159] = 1; CONVFMT = \"%.6g\";"
+								+ " for (k in a) print k }")
+				.expectLines("3.14")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testInOperatorConvertsKeyWithCurrentConvfmt() throws Exception {
+		AwkTestSupport
+				.awkTest("in operator converts its key with the current CONVFMT")
+				.script(
+						"BEGIN { a[12.153] = 1; print (12.153 in a);"
+								+ " CONVFMT = \"%.0f\"; print (12.153 in a), ((12.153) in a) }")
+				.expectLines("1", "0 0")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testDeleteConvertsKeyWithCurrentConvfmt() throws Exception {
+		AwkTestSupport
+				.awkTest("delete converts its key with the current CONVFMT")
+				.script(
+						"BEGIN { a[12.153] = 1; CONVFMT = \"%.0f\"; delete a[12.153];"
+								+ " print length(a) }")
+				.expectLines("1")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testIntegralSubscriptsUnaffectedByConvfmt() throws Exception {
+		AwkTestSupport
+				.awkTest("integral subscripts are not affected by CONVFMT")
+				.script(
+						"BEGIN { n = split(\"aaa bbb\", arr); CONVFMT = \"%.2f\"; i = 1.0;"
+								+ " print arr[i], arr[2], (2 in arr), (2.0 in arr) }")
+				.expectLines("aaa bbb 1 1")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testDeleteArrayKeepsInjectedMapBoundForLaterWrites() throws Exception {
 		Map<Object, Object> data = new LinkedHashMap<>();
 		data.put("a", "alpha");

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -24,8 +24,6 @@ package io.jawk;
 
 import static org.junit.Assert.*;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -38,6 +36,20 @@ import io.jawk.jrt.AssocArray;
 import io.jawk.jrt.AwkRuntimeException;
 
 public class AssocArrayTest {
+
+	@Test
+	public void testIsIntegralNumberKey() {
+		assertTrue(AssocArray.isIntegralNumberKey(Long.valueOf(5L)));
+		assertTrue(AssocArray.isIntegralNumberKey(Integer.valueOf(5)));
+		assertTrue(AssocArray.isIntegralNumberKey(Double.valueOf(5.0)));
+		assertTrue(AssocArray.isIntegralNumberKey(Double.valueOf(-0.0)));
+		assertFalse(AssocArray.isIntegralNumberKey(Double.valueOf(5.5)));
+		assertFalse(AssocArray.isIntegralNumberKey(Double.valueOf(0x1p63)));
+		assertFalse(AssocArray.isIntegralNumberKey(Double.valueOf(Double.NaN)));
+		assertFalse(AssocArray.isIntegralNumberKey(Float.valueOf(5.0f)));
+		assertFalse(AssocArray.isIntegralNumberKey("5"));
+		assertFalse(AssocArray.isIntegralNumberKey(null));
+	}
 
 	@Test
 	public void testInOperatorWithNumericAndStringKeys() {
@@ -360,41 +372,16 @@ public class AssocArrayTest {
 	}
 
 	@Test
-	public void testInjectMapVariableKeepsNumberKeys() throws Exception {
+	public void testInjectMapVariableKeepsIntegralDoubleKeys() throws Exception {
 		Map<Object, Object> data = new LinkedHashMap<>();
 		data.put(Double.valueOf(1.0), "one");
-		data.put(Float.valueOf(2.0f), "two");
-		data.put(Short.valueOf((short) 3), "three");
-		data.put(BigInteger.valueOf(Long.MAX_VALUE), "big");
-		data.put(BigDecimal.valueOf(Long.MAX_VALUE), "bigdec");
 
 		AwkTestSupport
-				.awkTest("injected Map Number keys stay reachable with same-typed subscripts")
-				.script(
-						"BEGIN{ print arr[d], (d in arr), arr[f], (f in arr), arr[s], (s in arr),"
-								+ " arr[b], (b in arr), arr[bd], (bd in arr) }")
+				.awkTest("injected Map Double keys stay reachable with a Double subscript")
+				.script("BEGIN{ print arr[idx], (idx in arr) }")
 				.preassign("arr", data)
-				.preassign("d", Double.valueOf(1.0))
-				.preassign("f", Float.valueOf(2.0f))
-				.preassign("s", Short.valueOf((short) 3))
-				.preassign("b", BigInteger.valueOf(Long.MAX_VALUE))
-				.preassign("bd", BigDecimal.valueOf(Long.MAX_VALUE))
-				.expectLines("one 1 two 1 three 1 big 1 bigdec 1")
-				.runAndAssert();
-	}
-
-	@Test
-	public void testArbitraryPrecisionIntegerSubscriptsKeepExactDigits() throws Exception {
-		AwkTestSupport
-				.awkTest("arbitrary-precision integer subscripts key as their exact digits")
-				.script(
-						"BEGIN { a[n1] = 1; a[n2] = 2; print length(a),"
-								+ " (\"9223372036854775808\" in a), (\"9223372036854775809\" in a);"
-								+ " b[n1, 0] = 1; b[n2, 0] = 2; print length(b),"
-								+ " ((\"9223372036854775808\" SUBSEP \"0\") in b) }")
-				.preassign("n1", new BigInteger("9223372036854775808"))
-				.preassign("n2", new BigInteger("9223372036854775809"))
-				.expectLines("2 1 1", "2 1")
+				.preassign("idx", Double.valueOf(1.0))
+				.expectLines("one 1")
 				.runAndAssert();
 	}
 

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -436,6 +436,17 @@ public class AssocArrayTest {
 	}
 
 	@Test
+	public void testOutOfLongRangeIntegralSubscriptKeysAsExactDigits() throws Exception {
+		AwkTestSupport
+				.awkTest("integral subscript beyond the signed 64-bit range keys as its exact digits")
+				.script(
+						"BEGIN { a[2^63] = 1; for (i in a) print i; print (2^63 in a);"
+								+ " CONVFMT = \"%.0f\"; print (2^63 in a) }")
+				.expectLines("9223372036854775808", "1", "1")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testIntegralSubscriptsUnaffectedByConvfmt() throws Exception {
 		AwkTestSupport
 				.awkTest("integral subscripts are not affected by CONVFMT")

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -437,6 +437,28 @@ public class AssocArrayTest {
 	}
 
 	@Test
+	public void testInOperatorJoinsMultidimKeyAfterArrayOperandEvaluation() throws Exception {
+		AwkTestSupport
+				.awkTest("in operator joins a multi-dimensional key after the array operand is evaluated")
+				.script(
+						"function f() { CONVFMT = \"%.0f\"; return \"x\" }"
+								+ " BEGIN { outer[\"x\"][1.2, 2.3] = 1; CONVFMT = \"%.6g\";"
+								+ " print ((1.2, 2.3) in outer[f()]) }")
+				.expectLines("0")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testNonIntegralFloatSubscriptConvertsAtCreation() throws Exception {
+		AwkTestSupport
+				.awkTest("non-integral Float subscript keys as its CONVFMT string at creation")
+				.script("BEGIN { a[f] = 1; CONVFMT = \"%.0f\"; for (k in a) print k; print (12.153 in a) }")
+				.preassign("f", Float.valueOf(12.153f))
+				.expectLines("12.153", "0")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testDeleteConvertsKeyWithCurrentConvfmt() throws Exception {
 		AwkTestSupport
 				.awkTest("delete converts its key with the current CONVFMT")

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -358,6 +358,20 @@ public class AssocArrayTest {
 	}
 
 	@Test
+	public void testInjectMapVariableKeepsIntegralDoubleKeys() throws Exception {
+		Map<Object, Object> data = new LinkedHashMap<>();
+		data.put(Double.valueOf(1.0), "one");
+
+		AwkTestSupport
+				.awkTest("injected Map Double keys stay reachable with a Double subscript")
+				.script("BEGIN{ print arr[idx], (idx in arr) }")
+				.preassign("arr", data)
+				.preassign("idx", Double.valueOf(1.0))
+				.expectLines("one 1")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testSingleDimensionSubscriptKeyFixedAtCreationTime() throws Exception {
 		AwkTestSupport
 				.awkTest("single-dimension subscript keeps its key after CONVFMT changes")

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -384,6 +384,19 @@ public class AssocArrayTest {
 	}
 
 	@Test
+	public void testArbitraryPrecisionIntegerSubscriptsKeepExactDigits() throws Exception {
+		AwkTestSupport
+				.awkTest("arbitrary-precision integer subscripts key as their exact digits")
+				.script(
+						"BEGIN { a[n1] = 1; a[n2] = 2; print length(a),"
+								+ " (\"9223372036854775808\" in a), (\"9223372036854775809\" in a) }")
+				.preassign("n1", new BigInteger("9223372036854775808"))
+				.preassign("n2", new BigInteger("9223372036854775809"))
+				.expectLines("2 1 1")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testSingleDimensionSubscriptKeyFixedAtCreationTime() throws Exception {
 		AwkTestSupport
 				.awkTest("single-dimension subscript keeps its key after CONVFMT changes")

--- a/src/test/java/io/jawk/AssocArrayTest.java
+++ b/src/test/java/io/jawk/AssocArrayTest.java
@@ -425,6 +425,18 @@ public class AssocArrayTest {
 	}
 
 	@Test
+	public void testInOperatorConvertsKeyAfterArrayOperandEvaluation() throws Exception {
+		AwkTestSupport
+				.awkTest("in operator converts its key after the array operand is evaluated")
+				.script(
+						"function f() { CONVFMT = \"%.0f\"; return \"x\" }"
+								+ " BEGIN { outer[\"x\"][12.153] = 1; CONVFMT = \"%.6g\";"
+								+ " print (12.153 in outer[f()]) }")
+				.expectLines("0")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testDeleteConvertsKeyWithCurrentConvfmt() throws Exception {
 		AwkTestSupport
 				.awkTest("delete converts its key with the current CONVFMT")

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1091,6 +1091,21 @@ public class AwkTest {
 	}
 
 	@Test
+	public void testMultilineGroupedInKeyReportsSubscriptStartLineNumber() throws Exception {
+		assertRuntimeExceptionLineNumber(
+				"multi-line grouped in key reports the line where the subscript starts",
+				5,
+				"Attempting to use an array in a scalar context.",
+				"BEGIN {", // 1
+				"  a[1] = 1", // 2
+				"  b[1, 2] = 2", // 3
+				"", // 4
+				"  if ((a,", // 5
+				"       1) in b) print \"member\"", // 6
+				"}"); // 7
+	}
+
+	@Test
 	public void testArraysOfArraysReadAutovivifiesMissingParentSubarray() throws Exception {
 		AwkTestSupport
 				.awkTest("arrays of arrays read autovivifies missing parent subarray")

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1077,6 +1077,20 @@ public class AwkTest {
 	}
 
 	@Test
+	public void testSharedIdentifierSubscriptReportsCurrentLineNumber() throws Exception {
+		assertRuntimeExceptionLineNumber(
+				"shared identifier used as scalar subscript reports the subscript line",
+				5,
+				"Attempting to use an array in a scalar context.",
+				"BEGIN {", // 1
+				"  a[1] = 1", // 2
+				"", // 3
+				"  b[1] = 2", // 4
+				"  print b[a]", // 5
+				"}"); // 6
+	}
+
+	@Test
 	public void testArraysOfArraysReadAutovivifiesMissingParentSubarray() throws Exception {
 		AwkTestSupport
 				.awkTest("arrays of arrays read autovivifies missing parent subarray")

--- a/src/test/java/io/jawk/AwkTest.java
+++ b/src/test/java/io/jawk/AwkTest.java
@@ -1106,6 +1106,21 @@ public class AwkTest {
 	}
 
 	@Test
+	public void testMultilinePrintGroupedInKeyReportsSubscriptStartLineNumber() throws Exception {
+		assertRuntimeExceptionLineNumber(
+				"multi-line print grouped in key reports the line where the subscript starts",
+				5,
+				"Attempting to use an array in a scalar context.",
+				"BEGIN {", // 1
+				"  a[1] = 1", // 2
+				"  b[1, 2] = 2", // 3
+				"", // 4
+				"  print (a,", // 5
+				"         1) in b", // 6
+				"}"); // 7
+	}
+
+	@Test
 	public void testArraysOfArraysReadAutovivifiesMissingParentSubarray() throws Exception {
 		AwkTestSupport
 				.awkTest("arrays of arrays read autovivifies missing parent subarray")


### PR DESCRIPTION
Fixes #547.

## Problem

An array subscript must be converted to a string with the `CONVFMT` in effect **when the element is created**, and that string is the key from then on. Jawk never converted a single-dimension subscript: it stored the raw `Double` as the key and converted lazily on read, so a later `CONVFMT` change retroactively altered existing keys. This cost two gawk compatibility tests: `GawkIT.test_arynasty` and `GawkIT.test_ofmta`.

## Fix

- `ArrayIndexAst.populateTuples` now always emits `APPLY_SUBSEP` (previously only when `cnt > 1`), so every subscript is stringified at the point of use — element creation, reads, `delete`, and membership tests.
- The `in` operator converts its key with the `CONVFMT`/`SUBSEP` in effect **when the operator executes**, i.e. after the array operand has been evaluated (it may have side effects), matching gawk's conversion timing and left-to-right operand evaluation order (both gawk-verified). Since the key components sit under the array operand on the stack, a new `APPLY_SUBSEP_UNDER_TOP` opcode (appended at the end of the enum to keep precompiled-tuple ordinals stable) converts them in place.
- Integral subscripts skip the string round-trip: `AssocArray.isIntegralNumberKey()` (next to `normalizeKey()`/`toLongKey()`, whose canonicalization it describes) recognizes an integral `Long`/`Integer`/`Double`, which the array implementations canonicalize to the same `Long` key as its string form — so integer-indexed loops stay fast, `split()`-array interop is unchanged, and injected plain `Map` variables keep exact `Double` key semantics. Every other scalar converts through `jrt.toAwkString()`. Integral values beyond the signed 64-bit range key as their exact digits like gawk: `a[2^63]` creates `9223372036854775808` (previously clamped to `Long.MAX_VALUE`).
- Subscript line numbers are captured where the subscript starts during parsing (shared identifier nodes carry their first occurrence's line, and the lexer reads ahead past line ends), so the "array in a scalar context" error reports the right line for bracketed, grouped, and print-parenthesized subscripts, including multi-line groups.
- `AwkTuples.serialVersionUID` bumped to 4: pre-change precompiled programs lack the conversion tuples and are now rejected with the existing "please recompile" message instead of silently keeping the old behavior.

## Verification

- New script tests in `AssocArrayTest`/`AwkTest` (gawk behavior verified empirically for each semantic case): key fixed at creation (single & multi-dim), creation under non-default `CONVFMT`, `in`/`delete` converting with the current `CONVFMT`, conversion-after-array-operand timing (single & multi-dim), integral subscripts immune to `CONVFMT`, injected plain-`Map` `Double` keys preserved, non-integral `Float` binding keyed at creation, `a[2^63]` exact digits, error line numbers, and a direct unit test of `AssocArray.isIntegralNumberKey()`.
- Full `mvn verify site` passes (surefire, checkstyle, pmd, spotbugs all clean).
- Before/after diff of the failing-test set across all four IT suites (parameterized names preserved), baseline from `main` in a separate worktree:
  - **Fixed**: `io.jawk.gawk.GawkIT.test_arynasty`, `io.jawk.gawk.GawkIT.test_ofmta`
  - **Regressed**: none (151 → 149 failing ITs, stable across all thirteen verify runs of this branch)
- Behavior changes documented under `Unreleased` in `src/site/markdown/behavior-changes.md`.

## Scope note (maintainer decision)

Subscript conversion only distinguishes the number types AWK code itself produces (`Long`/`Integer`/`Double`). Exotic `Number` bindings from JSR-223 or extensions (`Float`, `Short`, `BigInteger`, `BigDecimal`, ...) convert through `jrt.toAwkString()` like any scalar: they do not keep exact-typed keys in injected plain `Map`s, and arbitrary-precision values beyond the double's exactness project through `double`. This keeps the rule lean; the earlier per-type exact-value machinery was removed in e19ed10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
