### PR TITLE
Compute integral arithmetic exactly in 64 bits, reducing Double re-boxing

### DIFF
--- a/src/jmh/java/io/jawk/AwkScriptBenchmark.java
+++ b/src/jmh/java/io/jawk/AwkScriptBenchmark.java
@@ -51,6 +51,7 @@ public class AwkScriptBenchmark {
 	private Awk awk;
 	private AwkProgram sumInputProgram;
 	private AwkProgram projectMatchingProgram;
+	private AwkProgram arithmeticLoopProgram;
 	private String mixedNumericInput;
 
 	/**
@@ -69,6 +70,9 @@ public class AwkScriptBenchmark {
 		this.projectMatchingProgram = this.awk
 				.compile(
 						"/^input/ { print $1, $2 + 1, ($2 ~ /^[0-9]/) }\n");
+		this.arithmeticLoopProgram = this.awk
+				.compile(
+						"BEGIN { s = 0; for (i = 0; i < 50000; i++) s = s + i; print s }\n");
 		this.mixedNumericInput = "input 10\n"
 				+ "input 3.14\n"
 				+ "input 0\n"
@@ -102,5 +106,19 @@ public class AwkScriptBenchmark {
 	@Benchmark
 	public String projectMatchingValues() throws IOException, ExitException {
 		return this.awk.script(this.projectMatchingProgram).input(this.mixedNumericInput).execute();
+	}
+
+	/**
+	 * Measures a tight interpreter loop of increments, comparisons, and
+	 * additions, the hot path targeted by the arithmetic boxing work
+	 * (<a href="https://github.com/jawkio/jawk/issues/537">#537</a>).
+	 *
+	 * @return script output
+	 * @throws IOException if execution fails
+	 * @throws ExitException if the script exits non-zero
+	 */
+	@Benchmark
+	public String tightArithmeticLoop() throws IOException, ExitException {
+		return this.awk.script(this.arithmeticLoopProgram).input("").execute();
 	}
 }

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -3778,14 +3778,14 @@ public class AVM implements VariableManager, Closeable {
 	}
 
 	private void setNumOnJRT(long fieldNum, Object num) {
-		String numString = jrt.toAwkString(num);
-
-		// same code as ASSIGN_AS_INPUT_FIELD
+		// same code as ASSIGN_AS_INPUT_FIELD: a field retains the numeric
+		// scalar itself (so an exact integer survives repeated arithmetic),
+		// while $0 is record text and converts with CONVFMT immediately
 		if (fieldNum == 0) {
-			jrt.setInputLine(numString);
+			jrt.setInputLine(jrt.toAwkString(num));
 			jrt.jrtParseFields();
 		} else {
-			jrt.jrtSetInputField(numString, fieldNum);
+			jrt.jrtSetInputField(num, fieldNum);
 		}
 	}
 

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -1235,15 +1235,20 @@ public class AVM implements VariableManager, Closeable {
 				case NEGATE: {
 					// stack[0] = item to numerically negate
 
-					double d = JRT.toDouble(pop());
-					push(-d);
+					push(JRT.negate(pop()));
 					position.next();
 					break;
 				}
 				case UNARY_PLUS: {
 					// stack[0] = item to convert to a number
-					double d = JRT.toDouble(pop());
-					push(d);
+					Object o = pop();
+					// A numeric scalar is already a number: pushing it back
+					// unchanged avoids both re-boxing and precision loss.
+					if (o instanceof Long || o instanceof Integer || o instanceof Double) {
+						push(o);
+					} else {
+						push(JRT.toDouble(o));
+					}
 					position.next();
 					break;
 				}
@@ -1357,33 +1362,30 @@ public class AVM implements VariableManager, Closeable {
 					long offset = variableTuple.getVariableOffset();
 					boolean isGlobal = variableTuple.isGlobal();
 
-					double val = JRT.toDouble(rhs);
-
 					Map<Object, Object> array = ensureMapVariable(offset, isGlobal);
 					checkScalar(arrIdx);
 					Object o = array.get(arrIdx);
-					double origVal = JRT.toDouble(o);
 
-					double newVal;
+					Object newVal;
 
 					switch (opcode) {
 					case PLUS_EQ_ARRAY:
-						newVal = origVal + val;
+						newVal = JRT.add(o, rhs);
 						break;
 					case MINUS_EQ_ARRAY:
-						newVal = origVal - val;
+						newVal = JRT.subtract(o, rhs);
 						break;
 					case MULT_EQ_ARRAY:
-						newVal = origVal * val;
+						newVal = JRT.multiply(o, rhs);
 						break;
 					case DIV_EQ_ARRAY:
-						newVal = origVal / val;
+						newVal = JRT.divide(o, rhs);
 						break;
 					case MOD_EQ_ARRAY:
-						newVal = origVal % val;
+						newVal = JRT.mod(o, rhs);
 						break;
 					case POW_EQ_ARRAY:
-						newVal = Math.pow(origVal, val);
+						newVal = JRT.pow(o, rhs);
 						break;
 					default:
 						throw new Error("Invalid op code here: " + opcode);
@@ -1409,30 +1411,28 @@ public class AVM implements VariableManager, Closeable {
 						rhs = BLANK;
 					}
 
-					double val = JRT.toDouble(rhs);
 					checkScalar(arrIdx);
 					Object o = array.get(arrIdx);
-					double origVal = JRT.toDouble(o);
-					double newVal;
+					Object newVal;
 
 					switch (opcode) {
 					case PLUS_EQ_MAP_ELEMENT:
-						newVal = origVal + val;
+						newVal = JRT.add(o, rhs);
 						break;
 					case MINUS_EQ_MAP_ELEMENT:
-						newVal = origVal - val;
+						newVal = JRT.subtract(o, rhs);
 						break;
 					case MULT_EQ_MAP_ELEMENT:
-						newVal = origVal * val;
+						newVal = JRT.multiply(o, rhs);
 						break;
 					case DIV_EQ_MAP_ELEMENT:
-						newVal = origVal / val;
+						newVal = JRT.divide(o, rhs);
 						break;
 					case MOD_EQ_MAP_ELEMENT:
-						newVal = origVal % val;
+						newVal = JRT.mod(o, rhs);
 						break;
 					case POW_EQ_MAP_ELEMENT:
-						newVal = Math.pow(origVal, val);
+						newVal = JRT.pow(o, rhs);
 						break;
 					default:
 						throw new Error("Invalid op code here: " + opcode);
@@ -1481,27 +1481,25 @@ public class AVM implements VariableManager, Closeable {
 					boolean isGlobal = variableTuple.isGlobal();
 					Object o1 = resolveVariable(offset, isGlobal, false);
 					Object o2 = pop();
-					double d1 = JRT.toDouble(o1);
-					double d2 = JRT.toDouble(o2);
-					double ans;
+					Object ans;
 					switch (opcode) {
 					case PLUS_EQ:
-						ans = d1 + d2;
+						ans = JRT.add(o1, o2);
 						break;
 					case MINUS_EQ:
-						ans = d1 - d2;
+						ans = JRT.subtract(o1, o2);
 						break;
 					case MULT_EQ:
-						ans = d1 * d2;
+						ans = JRT.multiply(o1, o2);
 						break;
 					case DIV_EQ:
-						ans = d1 / d2;
+						ans = JRT.divide(o1, o2);
 						break;
 					case MOD_EQ:
-						ans = d1 % d2;
+						ans = JRT.mod(o1, o2);
 						break;
 					case POW_EQ:
-						ans = Math.pow(d1, d2);
+						ans = JRT.pow(o1, o2);
 						break;
 					default:
 						throw new Error("Invalid opcode here: " + opcode);
@@ -1601,8 +1599,7 @@ public class AVM implements VariableManager, Closeable {
 					Object key = pop();
 					checkScalar(key);
 					Object o = aa.get(key);
-					double ans = JRT.toDouble(o) + 1;
-					aa.put(key, ans);
+					aa.put(key, JRT.inc(blankToZero(o)));
 					position.next();
 					break;
 				}
@@ -1616,8 +1613,7 @@ public class AVM implements VariableManager, Closeable {
 					Object key = pop();
 					checkScalar(key);
 					Object o = aa.get(key);
-					double ans = JRT.toDouble(o) - 1;
-					aa.put(key, ans);
+					aa.put(key, JRT.dec(blankToZero(o)));
 					position.next();
 					break;
 				}
@@ -1628,8 +1624,7 @@ public class AVM implements VariableManager, Closeable {
 					checkScalar(key);
 					Map<Object, Object> aa = toMap(pop());
 					Object o = aa.get(key);
-					double ans = JRT.toDouble(o) + 1;
-					aa.put(key, ans);
+					aa.put(key, JRT.inc(blankToZero(o)));
 					position.next();
 					break;
 				}
@@ -1640,8 +1635,7 @@ public class AVM implements VariableManager, Closeable {
 					checkScalar(key);
 					Map<Object, Object> aa = toMap(pop());
 					Object o = aa.get(key);
-					double ans = JRT.toDouble(o) - 1;
-					aa.put(key, ans);
+					aa.put(key, JRT.dec(blankToZero(o)));
 					position.next();
 					break;
 				}
@@ -1947,10 +1941,7 @@ public class AVM implements VariableManager, Closeable {
 					// stack[1] = item1
 					Object o2 = pop();
 					Object o1 = pop();
-					double d1 = JRT.toDouble(o1);
-					double d2 = JRT.toDouble(o2);
-					double ans = d1 + d2;
-					push(ans);
+					push(JRT.add(o1, o2));
 					position.next();
 					break;
 				}
@@ -1959,10 +1950,7 @@ public class AVM implements VariableManager, Closeable {
 					// stack[1] = item1
 					Object o2 = pop();
 					Object o1 = pop();
-					double d1 = JRT.toDouble(o1);
-					double d2 = JRT.toDouble(o2);
-					double ans = d1 - d2;
-					push(ans);
+					push(JRT.subtract(o1, o2));
 					position.next();
 					break;
 				}
@@ -1971,10 +1959,7 @@ public class AVM implements VariableManager, Closeable {
 					// stack[1] = item1
 					Object o2 = pop();
 					Object o1 = pop();
-					double d1 = JRT.toDouble(o1);
-					double d2 = JRT.toDouble(o2);
-					double ans = d1 * d2;
-					push(ans);
+					push(JRT.multiply(o1, o2));
 					position.next();
 					break;
 				}
@@ -1983,10 +1968,7 @@ public class AVM implements VariableManager, Closeable {
 					// stack[1] = item1
 					Object o2 = pop();
 					Object o1 = pop();
-					double d1 = JRT.toDouble(o1);
-					double d2 = JRT.toDouble(o2);
-					double ans = d1 / d2;
-					push(ans);
+					push(JRT.divide(o1, o2));
 					position.next();
 					break;
 				}
@@ -1995,10 +1977,7 @@ public class AVM implements VariableManager, Closeable {
 					// stack[1] = item1
 					Object o2 = pop();
 					Object o1 = pop();
-					double d1 = JRT.toDouble(o1);
-					double d2 = JRT.toDouble(o2);
-					double ans = d1 % d2;
-					push(ans);
+					push(JRT.mod(o1, o2));
 					position.next();
 					break;
 				}
@@ -2007,10 +1986,7 @@ public class AVM implements VariableManager, Closeable {
 					// stack[1] = item1
 					Object o2 = pop();
 					Object o1 = pop();
-					double d1 = JRT.toDouble(o1);
-					double d2 = JRT.toDouble(o2);
-					double ans = Math.pow(d1, d2);
-					push(ans);
+					push(JRT.pow(o1, o2));
 					position.next();
 					break;
 				}
@@ -3875,6 +3851,15 @@ public class AVM implements VariableManager, Closeable {
 	 * Numerically increases an Awk variable by one; the result
 	 * is placed back into that variable.
 	 */
+	/**
+	 * Replaces a missing or uninitialized array element by numeric zero, so
+	 * that {@code ++}/{@code --} on it starts from an exact integer, the same
+	 * way {@link #inc(long, boolean)} treats an uninitialized variable.
+	 */
+	private static Object blankToZero(Object o) {
+		return o == null || o instanceof UninitializedObject ? ZERO : o;
+	}
+
 	private Object inc(long l, boolean isGlobal) {
 		Object o = resolveVariable(l, isGlobal, false);
 		if (o instanceof UninitializedObject) {

--- a/src/main/java/io/jawk/backend/AVM.java
+++ b/src/main/java/io/jawk/backend/AVM.java
@@ -1241,14 +1241,9 @@ public class AVM implements VariableManager, Closeable {
 				}
 				case UNARY_PLUS: {
 					// stack[0] = item to convert to a number
-					Object o = pop();
 					// A numeric scalar is already a number: pushing it back
 					// unchanged avoids both re-boxing and precision loss.
-					if (o instanceof Long || o instanceof Integer || o instanceof Double) {
-						push(o);
-					} else {
-						push(JRT.toDouble(o));
-					}
+					push(numericValueOf(pop()));
 					position.next();
 					break;
 				}
@@ -1364,7 +1359,7 @@ public class AVM implements VariableManager, Closeable {
 
 					Map<Object, Object> array = ensureMapVariable(offset, isGlobal);
 					checkScalar(arrIdx);
-					Object o = array.get(arrIdx);
+					Object o = blankToZero(array.get(arrIdx));
 
 					Object newVal;
 
@@ -1412,7 +1407,7 @@ public class AVM implements VariableManager, Closeable {
 					}
 
 					checkScalar(arrIdx);
-					Object o = array.get(arrIdx);
+					Object o = blankToZero(array.get(arrIdx));
 					Object newVal;
 
 					switch (opcode) {
@@ -1479,7 +1474,7 @@ public class AVM implements VariableManager, Closeable {
 					VariableTuple variableTuple = (VariableTuple) tuple;
 					long offset = variableTuple.getVariableOffset();
 					boolean isGlobal = variableTuple.isGlobal();
-					Object o1 = resolveVariable(offset, isGlobal, false);
+					Object o1 = blankToZero(resolveVariable(offset, isGlobal, false));
 					Object o2 = pop();
 					Object ans;
 					switch (opcode) {
@@ -1520,29 +1515,29 @@ public class AVM implements VariableManager, Closeable {
 
 					// same code as GET_INPUT_FIELD:
 					long fieldnum = JRT.parseFieldNumber(pop());
-					double incval = JRT.toDouble(pop());
+					Object incval = pop();
 
 					// except here, get the number, and add the incvalue
-					Object numObj = jrt.jrtGetInputField(fieldnum);
-					double num;
+					Object numObj = blankToZero(jrt.jrtGetInputField(fieldnum));
+					Object num;
 					switch (opcode) {
 					case PLUS_EQ_INPUT_FIELD:
-						num = JRT.toDouble(numObj) + incval;
+						num = JRT.add(numObj, incval);
 						break;
 					case MINUS_EQ_INPUT_FIELD:
-						num = JRT.toDouble(numObj) - incval;
+						num = JRT.subtract(numObj, incval);
 						break;
 					case MULT_EQ_INPUT_FIELD:
-						num = JRT.toDouble(numObj) * incval;
+						num = JRT.multiply(numObj, incval);
 						break;
 					case DIV_EQ_INPUT_FIELD:
-						num = JRT.toDouble(numObj) / incval;
+						num = JRT.divide(numObj, incval);
 						break;
 					case MOD_EQ_INPUT_FIELD:
-						num = JRT.toDouble(numObj) % incval;
+						num = JRT.mod(numObj, incval);
 						break;
 					case POW_EQ_INPUT_FIELD:
-						num = Math.pow(JRT.toDouble(numObj), incval);
+						num = JRT.pow(numObj, incval);
 						break;
 					default:
 						throw new Error("Invalid opcode here: " + opcode);
@@ -1643,12 +1638,11 @@ public class AVM implements VariableManager, Closeable {
 					// stack[0] = dollar index (field number)
 					long fieldnum = JRT.parseFieldNumber(pop());
 
-					Object numObj = jrt.jrtGetInputField(fieldnum);
-					double original = JRT.toDouble(numObj);
-					double num = original + 1;
-					setNumOnJRT(fieldnum, num);
+					Object numObj = blankToZero(jrt.jrtGetInputField(fieldnum));
+					Object original = numericValueOf(numObj);
+					setNumOnJRT(fieldnum, JRT.inc(original));
 
-					push(Double.valueOf(original));
+					push(original);
 
 					position.next();
 					break;
@@ -1658,12 +1652,11 @@ public class AVM implements VariableManager, Closeable {
 					// same code as GET_INPUT_FIELD:
 					long fieldnum = JRT.parseFieldNumber(pop());
 
-					Object numObj = jrt.jrtGetInputField(fieldnum);
-					double original = JRT.toDouble(numObj);
-					double num = original - 1;
-					setNumOnJRT(fieldnum, num);
+					Object numObj = blankToZero(jrt.jrtGetInputField(fieldnum));
+					Object original = numericValueOf(numObj);
+					setNumOnJRT(fieldnum, JRT.dec(original));
 
-					push(Double.valueOf(original));
+					push(original);
 
 					position.next();
 					break;
@@ -3784,8 +3777,8 @@ public class AVM implements VariableManager, Closeable {
 		return jrt.sprintf(fmt, argArray);
 	}
 
-	private void setNumOnJRT(long fieldNum, double num) {
-		String numString = jrt.toAwkString(Double.valueOf(num));
+	private void setNumOnJRT(long fieldNum, Object num) {
+		String numString = jrt.toAwkString(num);
 
 		// same code as ASSIGN_AS_INPUT_FIELD
 		if (fieldNum == 0) {
@@ -3858,6 +3851,17 @@ public class AVM implements VariableManager, Closeable {
 	 */
 	private static Object blankToZero(Object o) {
 		return o == null || o instanceof UninitializedObject ? ZERO : o;
+	}
+
+	/**
+	 * Coerces a scalar to its numeric value, keeping an already numeric
+	 * scalar unchanged so an exact integer is not rounded through a double.
+	 */
+	private static Object numericValueOf(Object o) {
+		if (o instanceof Long || o instanceof Integer || o instanceof Double) {
+			return o;
+		}
+		return JRT.toDouble(o);
 	}
 
 	private Object inc(long l, boolean isGlobal) {

--- a/src/main/java/io/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/io/jawk/intermediate/AwkTuples.java
@@ -50,10 +50,10 @@ import io.jawk.jrt.JRT;
  */
 public class AwkTuples implements Serializable {
 
-	// Bumped to 4 when single-dimension subscripts started emitting
-	// APPLY_SUBSEP: older tuple streams lack the conversion and must be
-	// recompiled.
-	private static final long serialVersionUID = 4L;
+	// Bumped to 5 when arithmetic on integral operands became exact in 64
+	// bits: older tuple streams carry constants folded in floating point and
+	// must be recompiled.
+	private static final long serialVersionUID = 5L;
 
 	/** Address manager */
 	private final AddressManager addressManager = new AddressManager();
@@ -2392,43 +2392,23 @@ public class AwkTuples implements Serializable {
 		if (opcode == null) {
 			return null;
 		}
+		// Arithmetic folds through the same JRT helpers the interpreter uses,
+		// and keeps their exact result type: normalizing an integral Double
+		// to a Long here would give the folded constant an exactness in later
+		// folds that the runtime result would not have.
 		switch (opcode) {
-		case ADD: {
-			double d1 = JRT.toDouble(left);
-			double d2 = JRT.toDouble(right);
-			double ans = d1 + d2;
-			return JRT.toScalarNumber(ans);
-		}
-		case SUBTRACT: {
-			double d1 = JRT.toDouble(left);
-			double d2 = JRT.toDouble(right);
-			double ans = d1 - d2;
-			return JRT.toScalarNumber(ans);
-		}
-		case MULTIPLY: {
-			double d1 = JRT.toDouble(left);
-			double d2 = JRT.toDouble(right);
-			double ans = d1 * d2;
-			return JRT.toScalarNumber(ans);
-		}
-		case DIVIDE: {
-			double d1 = JRT.toDouble(left);
-			double d2 = JRT.toDouble(right);
-			double ans = d1 / d2;
-			return JRT.toScalarNumber(ans);
-		}
-		case MOD: {
-			double d1 = JRT.toDouble(left);
-			double d2 = JRT.toDouble(right);
-			double ans = d1 % d2;
-			return JRT.toScalarNumber(ans);
-		}
-		case POW: {
-			double d1 = JRT.toDouble(left);
-			double d2 = JRT.toDouble(right);
-			double ans = Math.pow(d1, d2);
-			return JRT.toScalarNumber(ans);
-		}
+		case ADD:
+			return JRT.add(left, right);
+		case SUBTRACT:
+			return JRT.subtract(left, right);
+		case MULTIPLY:
+			return JRT.multiply(left, right);
+		case DIVIDE:
+			return JRT.divide(left, right);
+		case MOD:
+			return JRT.mod(left, right);
+		case POW:
+			return JRT.pow(left, right);
 		case CMP_EQ:
 		case CMP_LT:
 		case CMP_GT:
@@ -2455,15 +2435,15 @@ public class AwkTuples implements Serializable {
 			return null;
 		}
 		switch (opcode) {
-		case NEGATE: {
-			double value = JRT.toDouble(literal);
-			double ans = -value;
-			return JRT.toScalarNumber(ans);
-		}
-		case UNARY_PLUS: {
-			double value = JRT.toDouble(literal);
-			return JRT.toScalarNumber(value);
-		}
+		case NEGATE:
+			return JRT.negate(literal);
+		case UNARY_PLUS:
+			// The interpreter pushes a numeric scalar back unchanged; only a
+			// string literal needs the numeric conversion.
+			if (literal instanceof Long || literal instanceof Double) {
+				return literal;
+			}
+			return JRT.toDouble(literal);
 		default:
 			return null;
 		}

--- a/src/main/java/io/jawk/jrt/JRT.java
+++ b/src/main/java/io/jawk/jrt/JRT.java
@@ -2465,7 +2465,18 @@ public class JRT {
 	}
 
 	private String rebuildRecordTextFromFields(List<Object> fields) {
-		return joinFieldsWithLiteralSeparator(fields, ofs);
+		// A field assigned a numeric value retains the number itself;
+		// reconstituting $0 converts it with CONVFMT, as POSIX requires and
+		// gawk does (a string or input-derived field joins verbatim).
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < fields.size(); i++) {
+			if (i > 0) {
+				sb.append(ofs);
+			}
+			Object field = fields.get(i);
+			sb.append(field == null ? "" : toAwkString(field));
+		}
+		return sb.toString();
 	}
 
 	private final class RecordState {

--- a/src/main/java/io/jawk/jrt/JRT.java
+++ b/src/main/java/io/jawk/jrt/JRT.java
@@ -707,6 +707,155 @@ public class JRT {
 	}
 
 	/**
+	 * Returns whether a scalar is an exact 64-bit integer: a boxed
+	 * {@link Long} or {@link Integer}, whose value is known without any
+	 * floating-point rounding.
+	 *
+	 * @param o the scalar to examine
+	 * @return {@code true} when {@code o} is a {@code Long} or an
+	 *         {@code Integer}
+	 */
+	private static boolean isExactIntegral(Object o) {
+		return o instanceof Long || o instanceof Integer;
+	}
+
+	/**
+	 * Adds two AWK scalars. When both operands are exact 64-bit integers and
+	 * the sum fits in 64 bits, the result stays an exact {@link Long};
+	 * otherwise both operands are converted with {@link #toDouble(Object)}
+	 * and the result is a {@link Double}.
+	 *
+	 * @param o1 the left operand
+	 * @param o2 the right operand
+	 * @return {@code o1 + o2} as a canonical AWK scalar
+	 */
+	public static Object add(Object o1, Object o2) {
+		if (isExactIntegral(o1) && isExactIntegral(o2)) {
+			try {
+				return Math.addExact(((Number) o1).longValue(), ((Number) o2).longValue());
+			} catch (ArithmeticException overflow) {
+				return toDouble(o1) + toDouble(o2);
+			}
+		}
+		return toDouble(o1) + toDouble(o2);
+	}
+
+	/**
+	 * Subtracts two AWK scalars. When both operands are exact 64-bit integers
+	 * and the difference fits in 64 bits, the result stays an exact
+	 * {@link Long}; otherwise both operands are converted with
+	 * {@link #toDouble(Object)} and the result is a {@link Double}.
+	 *
+	 * @param o1 the left operand
+	 * @param o2 the right operand
+	 * @return {@code o1 - o2} as a canonical AWK scalar
+	 */
+	public static Object subtract(Object o1, Object o2) {
+		if (isExactIntegral(o1) && isExactIntegral(o2)) {
+			try {
+				return Math.subtractExact(((Number) o1).longValue(), ((Number) o2).longValue());
+			} catch (ArithmeticException overflow) {
+				return toDouble(o1) - toDouble(o2);
+			}
+		}
+		return toDouble(o1) - toDouble(o2);
+	}
+
+	/**
+	 * Multiplies two AWK scalars. When both operands are exact 64-bit
+	 * integers and the product fits in 64 bits, the result stays an exact
+	 * {@link Long}; otherwise both operands are converted with
+	 * {@link #toDouble(Object)} and the result is a {@link Double}.
+	 *
+	 * @param o1 the left operand
+	 * @param o2 the right operand
+	 * @return {@code o1 * o2} as a canonical AWK scalar
+	 */
+	public static Object multiply(Object o1, Object o2) {
+		if (isExactIntegral(o1) && isExactIntegral(o2)) {
+			try {
+				return Math.multiplyExact(((Number) o1).longValue(), ((Number) o2).longValue());
+			} catch (ArithmeticException overflow) {
+				return toDouble(o1) * toDouble(o2);
+			}
+		}
+		return toDouble(o1) * toDouble(o2);
+	}
+
+	/**
+	 * Divides two AWK scalars. When both operands are exact 64-bit integers
+	 * and the quotient is a 64-bit integer with no remainder, the result
+	 * stays an exact {@link Long}; every other case (a fractional quotient,
+	 * a zero divisor, or {@code Long.MIN_VALUE / -1}) is computed in
+	 * floating point, as before.
+	 *
+	 * @param o1 the dividend
+	 * @param o2 the divisor
+	 * @return {@code o1 / o2} as a canonical AWK scalar
+	 */
+	public static Object divide(Object o1, Object o2) {
+		if (isExactIntegral(o1) && isExactIntegral(o2)) {
+			long l1 = ((Number) o1).longValue();
+			long l2 = ((Number) o2).longValue();
+			if (l2 != 0 && l1 % l2 == 0 && (l1 != Long.MIN_VALUE || l2 != -1)) {
+				return l1 / l2;
+			}
+		}
+		return toDouble(o1) / toDouble(o2);
+	}
+
+	/**
+	 * Computes the remainder of two AWK scalars. When both operands are exact
+	 * 64-bit integers and the divisor is non-zero, the result stays an exact
+	 * {@link Long}; otherwise the remainder is computed in floating point,
+	 * so a zero divisor still yields {@code nan}.
+	 *
+	 * @param o1 the dividend
+	 * @param o2 the divisor
+	 * @return {@code o1 % o2} as a canonical AWK scalar
+	 */
+	public static Object mod(Object o1, Object o2) {
+		if (isExactIntegral(o1) && isExactIntegral(o2)) {
+			long l2 = ((Number) o2).longValue();
+			if (l2 != 0) {
+				return ((Number) o1).longValue() % l2;
+			}
+		}
+		return toDouble(o1) % toDouble(o2);
+	}
+
+	/**
+	 * Raises an AWK scalar to a power. Exponentiation is always computed in
+	 * floating point, like gawk's {@code ^} operator.
+	 *
+	 * @param o1 the base
+	 * @param o2 the exponent
+	 * @return {@code o1 ^ o2} as a {@link Double}
+	 */
+	public static Object pow(Object o1, Object o2) {
+		return Math.pow(toDouble(o1), toDouble(o2));
+	}
+
+	/**
+	 * Negates an AWK scalar. An exact 64-bit integer stays an exact
+	 * {@link Long} (except {@code Long.MIN_VALUE}, whose negation does not
+	 * fit); everything else is converted with {@link #toDouble(Object)} and
+	 * negated as a {@link Double}.
+	 *
+	 * @param o the scalar to negate
+	 * @return {@code -o} as a canonical AWK scalar
+	 */
+	public static Object negate(Object o) {
+		if (isExactIntegral(o)) {
+			long l = ((Number) o).longValue();
+			if (l != Long.MIN_VALUE) {
+				return -l;
+			}
+		}
+		return -toDouble(o);
+	}
+
+	/**
 	 * Convert a String, Long, or Double to Long.
 	 *
 	 * @param o Object to convert.
@@ -850,6 +999,15 @@ public class JRT {
 	 */
 	public static boolean compare2(Object o1, Object o2, int mode, boolean ignoreCase) {
 		if (o1 instanceof Number && o2 instanceof Number) {
+			if (isExactIntegral(o1) && isExactIntegral(o2)) {
+				// Compare exact 64-bit integers without the precision loss a
+				// double conversion would introduce beyond 2^53.
+				int comparison = Long.compare(((Number) o1).longValue(), ((Number) o2).longValue());
+				if (mode == 0) {
+					return comparison == 0;
+				}
+				return mode < 0 ? comparison < 0 : comparison > 0;
+			}
 			return compareNumbers(((Number) o1).doubleValue(), ((Number) o2).doubleValue(), mode);
 		}
 
@@ -1061,31 +1219,43 @@ public class JRT {
 
 	/**
 	 * Return an object which is numerically equivalent to
-	 * one plus a given object. For Integers and Doubles,
-	 * this is similar to o+1. For Strings, attempts are
-	 * made to convert it to a double first. If the
-	 * String does not contain a numeric prefix, 1 is returned.
+	 * one plus a given object. An exact 64-bit integer stays an exact
+	 * {@link Long} (unless the increment overflows). For other numbers and
+	 * for Strings, the value is converted to a double first; a String
+	 * without a numeric prefix counts as 0, so the result is 1.
 	 *
 	 * @param o The object to increase.
 	 * @return {@code o + 1} if o is numeric or contains a numeric prefix;
 	 *         otherwise, {@code 1.0}
 	 */
 	public static Object inc(Object o) {
+		if (isExactIntegral(o)) {
+			long l = ((Number) o).longValue();
+			if (l != Long.MAX_VALUE) {
+				return l + 1;
+			}
+		}
 		return toDouble(o) + 1;
 	}
 
 	/**
 	 * Return an object which is numerically equivalent to
-	 * one minus a given object. For Integers and Doubles,
-	 * this is similar to o-1. For Strings, attempts are
-	 * made to convert it to a double first. If the
-	 * String does not contain a numeric prefix, -1 is returned.
+	 * one minus a given object. An exact 64-bit integer stays an exact
+	 * {@link Long} (unless the decrement overflows). For other numbers and
+	 * for Strings, the value is converted to a double first; a String
+	 * without a numeric prefix counts as 0, so the result is -1.
 	 *
 	 * @param o The object to increase.
 	 * @return {@code o - 1} if o is numeric or contains a numeric prefix;
 	 *         otherwise, {@code -1.0}
 	 */
 	public static Object dec(Object o) {
+		if (isExactIntegral(o)) {
+			long l = ((Number) o).longValue();
+			if (l != Long.MIN_VALUE) {
+				return l - 1;
+			}
+		}
 		return toDouble(o) - 1;
 	}
 

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -33,6 +33,12 @@ released version automatically via .github/scripts/stamp-behavior-changes.sh.
   zero: with `x = 0`, `1/-x` now prints `inf` (previously `-inf`). Programs precompiled with an
   earlier version are rejected and must be recompiled, since they may carry constants folded in
   floating point ([#537](https://github.com/jawkio/jawk/issues/537)).
+- A field updated with a compound assignment or `++`/`--` now retains its numeric value, like a
+  field assigned with `=` always did, instead of being replaced by its `CONVFMT` string, so
+  repeated updates stay exact and `print $1` shows the full value. When `$0` is reconstituted,
+  numeric field values are now converted with `CONVFMT`, as POSIX requires and gawk does:
+  `{ $1 = 0.1 + 0.2; print }` prints `0.3 ...` (previously `0.30000000000000004 ...`, the raw
+  Java rendering of the double) ([#537](https://github.com/jawkio/jawk/issues/537)).
 - Array subscripts are now converted to their string key with the `CONVFMT` in effect at the
   moment the subscript is used, as POSIX requires and gawk does. Previously a single-dimension
   numeric subscript was stored as a number and converted lazily, so a later `CONVFMT` change

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -20,7 +20,17 @@ released version automatically via .github/scripts/stamp-behavior-changes.sh.
 
 ## Unreleased
 
-- Array subscripts are now converted to their string key with the `CONVFMT` in effect at the
+- Arithmetic on integral operands is now computed in exact 64-bit integers when the result fits:
+  `+`, `-`, `*`, an evenly-dividing `/`, `%`, unary `-` and `+`, `++`/`--`, and the corresponding
+  compound assignments keep all their digits beyond 2^53, and comparisons between two such values
+  are exact as well. `print 9007199254740992 + 1` now prints `9007199254740993` (previously
+  `9007199254740992`, which is also what gawk prints, as gawk computes in doubles unless run
+  with `-M`). A result that overflows 64 bits still falls back to floating point
+  (`print 9223372036854775806 + 2` prints `9223372036854775808`), and exponentiation and any
+  operation with a fractional or string operand are unchanged. Integer results carry no negative
+  zero: with `x = 0`, `1/-x` now prints `inf` (previously `-inf`). Programs precompiled with an
+  earlier version are rejected and must be recompiled, since they may carry constants folded in
+  floating point ([#537](https://github.com/jawkio/jawk/issues/537)).
   moment the subscript is used, as POSIX requires and gawk does. Previously a single-dimension
   numeric subscript was stored as a number and converted lazily, so a later `CONVFMT` change
   retroactively altered existing keys: `a = 12.153; test[a] = "hi"; CONVFMT = "%.0f"` now keeps

--- a/src/site/markdown/behavior-changes.md
+++ b/src/site/markdown/behavior-changes.md
@@ -22,8 +22,10 @@ released version automatically via .github/scripts/stamp-behavior-changes.sh.
 
 - Arithmetic on integral operands is now computed in exact 64-bit integers when the result fits:
   `+`, `-`, `*`, an evenly-dividing `/`, `%`, unary `-` and `+`, `++`/`--`, and the corresponding
-  compound assignments keep all their digits beyond 2^53, and comparisons between two such values
-  are exact as well. `print 9007199254740992 + 1` now prints `9007199254740993` (previously
+  compound assignments — on variables, array elements, and fields alike — keep all their digits
+  beyond 2^53, and comparisons between two such values are exact as well. A compound assignment
+  or `++`/`--` on an uninitialized variable, a missing array element, or a missing field starts
+  from integer zero, so counters built that way stay exact. `print 9007199254740992 + 1` now prints `9007199254740993` (previously
   `9007199254740992`, which is also what gawk prints, as gawk computes in doubles unless run
   with `-M`). A result that overflows 64 bits still falls back to floating point
   (`print 9223372036854775806 + 2` prints `9223372036854775808`), and exponentiation and any
@@ -31,6 +33,7 @@ released version automatically via .github/scripts/stamp-behavior-changes.sh.
   zero: with `x = 0`, `1/-x` now prints `inf` (previously `-inf`). Programs precompiled with an
   earlier version are rejected and must be recompiled, since they may carry constants folded in
   floating point ([#537](https://github.com/jawkio/jawk/issues/537)).
+- Array subscripts are now converted to their string key with the `CONVFMT` in effect at the
   moment the subscript is used, as POSIX requires and gawk does. Previously a single-dimension
   numeric subscript was stored as a number and converted lazily, so a later `CONVFMT` change
   retroactively altered existing keys: `a = 12.153; test[a] = "hi"; CONVFMT = "%.0f"` now keeps

--- a/src/site/markdown/compatibility.md.vm
+++ b/src/site/markdown/compatibility.md.vm
@@ -195,7 +195,9 @@ Arithmetic on integral operands (`+`, `-`, `*`, an evenly-dividing `/`, `%`, una
 alike) is computed in exact 64-bit integers when both operands and the result are 64-bit
 integers, and comparisons between two such values are exact as well. A compound assignment or
 `++`/`--` on an uninitialized variable, a missing array element, or a missing field starts from
-integer zero, so counters built that way stay exact. Within ±2^53 this is indistinguishable from gawk; beyond that, Jawk keeps every
+integer zero, so counters built that way stay exact. A field assigned or updated with a numeric
+value retains the number itself — `print $1` shows the full value, repeated updates stay exact,
+and the numeric value is converted with `CONVFMT` only when `$0` is reconstituted, as in gawk. Within ±2^53 this is indistinguishable from gawk; beyond that, Jawk keeps every
 digit where gawk — which computes in C doubles unless built with MPFR support and run with
 `-M` — rounds: `print 9007199254740992 + 1` prints `9007199254740993` in Jawk and
 `9007199254740992` in default gawk. A result that overflows 64 bits, an exponentiation (`^`),

--- a/src/site/markdown/compatibility.md.vm
+++ b/src/site/markdown/compatibility.md.vm
@@ -191,9 +191,11 @@ The date and time functions (`mktime()`, `strftime()`) follow the Java platform'
 ${esc.h}${esc.h}${esc.h} Integer arithmetic
 
 Arithmetic on integral operands (`+`, `-`, `*`, an evenly-dividing `/`, `%`, unary `-` and `+`,
-`++`/`--`, and the corresponding compound assignments) is computed in exact 64-bit integers when
-both operands and the result are 64-bit integers, and comparisons between two such values are
-exact as well. Within ±2^53 this is indistinguishable from gawk; beyond that, Jawk keeps every
+`++`/`--`, and the corresponding compound assignments, on variables, array elements, and fields
+alike) is computed in exact 64-bit integers when both operands and the result are 64-bit
+integers, and comparisons between two such values are exact as well. A compound assignment or
+`++`/`--` on an uninitialized variable, a missing array element, or a missing field starts from
+integer zero, so counters built that way stay exact. Within ±2^53 this is indistinguishable from gawk; beyond that, Jawk keeps every
 digit where gawk — which computes in C doubles unless built with MPFR support and run with
 `-M` — rounds: `print 9007199254740992 + 1` prints `9007199254740993` in Jawk and
 `9007199254740992` in default gawk. A result that overflows 64 bits, an exponentiation (`^`),

--- a/src/site/markdown/compatibility.md.vm
+++ b/src/site/markdown/compatibility.md.vm
@@ -188,6 +188,22 @@ The date and time functions (`mktime()`, `strftime()`) follow the Java platform'
 - A positive `mktime()` DST hint applies the zone's current daylight adjustment; zones without daylight saving time ignore the hint.
 - `strftime()`'s `%Z` prints the zone's current designation (the JDK's time zone data records historical offsets and DST rules, but not historical zone names), and timestamps before the common era use the JDK's year numbering rather than astronomical (negative) years.
 
+${esc.h}${esc.h}${esc.h} Integer arithmetic
+
+Arithmetic on integral operands (`+`, `-`, `*`, an evenly-dividing `/`, `%`, unary `-` and `+`,
+`++`/`--`, and the corresponding compound assignments) is computed in exact 64-bit integers when
+both operands and the result are 64-bit integers, and comparisons between two such values are
+exact as well. Within ±2^53 this is indistinguishable from gawk; beyond that, Jawk keeps every
+digit where gawk — which computes in C doubles unless built with MPFR support and run with
+`-M` — rounds: `print 9007199254740992 + 1` prints `9007199254740993` in Jawk and
+`9007199254740992` in default gawk. A result that overflows 64 bits, an exponentiation (`^`),
+and any operation with a fractional or string operand fall back to IEEE double arithmetic,
+matching gawk exactly. One consequence of computing in the integer domain is that there is no
+negative zero: when `x` is integer zero, `-x` yields plain `0` where double arithmetic would
+keep `-0.0`, so an expression that can observe the sign, such as `1/-x`, prints `inf`
+(previously `-inf`; gawk itself treats any division by zero as a fatal error, which Jawk
+deliberately does not).
+
 ${esc.h}${esc.h}${esc.h} printf and sprintf formatting
 
 `printf` and `sprintf` implement the POSIX AWK conversions with gawk's semantics: `%s` converts

--- a/src/test/java/io/jawk/ExactIntegerArithmeticTest.java
+++ b/src/test/java/io/jawk/ExactIntegerArithmeticTest.java
@@ -121,6 +121,46 @@ public class ExactIntegerArithmeticTest {
 				.stdin("a\n")
 				.expectLines("2")
 				.runAndAssert();
+		AwkTestSupport
+				.awkTest("A field must retain its numeric scalar across repeated updates")
+				.script("{ $1 = 9007199254740992; $1 += 1; $1 += 1; print $1 }")
+				.stdin("x\n")
+				.expectLines("9007199254740994")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Repeated ++ on a field must stay exact beyond 2^53")
+				.script("{ $1 = 9007199254740992; $1++; $1++; print $1, $0 }")
+				.stdin("x\n")
+				.expectLines("9007199254740994 9007199254740994")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testRecordRebuildConvertsNumericFieldsWithConvfmt() throws Exception {
+		AwkTestSupport
+				.awkTest("$0 must be rebuilt with CONVFMT, not raw double digits")
+				.script("{ $1 = 0.1 + 0.2; print }")
+				.stdin("x y\n")
+				.expectLines("0.3 y")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("A numeric field keeps its full value while $0 shows its CONVFMT form")
+				.script("{ CONVFMT = \"%.2g\"; $1 = 0.123456; print; print $1 }")
+				.stdin("x y\n")
+				.expectLines("0.12 y", "0.123456")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Input-derived fields join back verbatim")
+				.script("{ $3 = \"z\"; print }")
+				.stdin("0.30000000000000004 y w\n")
+				.expectLines("0.30000000000000004 y z")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("$NF++ on an empty record targets $0, which stays record text")
+				.script("{ print $NF++; print $NF }")
+				.stdin("\n")
+				.expectLines("0", "1")
+				.runAndAssert();
 	}
 
 	@Test

--- a/src/test/java/io/jawk/ExactIntegerArithmeticTest.java
+++ b/src/test/java/io/jawk/ExactIntegerArithmeticTest.java
@@ -96,6 +96,48 @@ public class ExactIntegerArithmeticTest {
 	}
 
 	@Test
+	public void testFieldArithmeticStaysExact() throws Exception {
+		AwkTestSupport
+				.awkTest("+= on a field holding an exact integer must stay exact beyond 2^53")
+				.script("{ $1 = 9007199254740992; $1 += 1; print $1 }")
+				.stdin("x\n")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("++ on a field holding an exact integer must stay exact beyond 2^53")
+				.script("{ $1 = 9007199254740992; $1++; print $1 }")
+				.stdin("x\n")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("++ on a field must yield the exact original value")
+				.script("{ $1 = 9007199254740993; print $1++ }")
+				.stdin("x\n")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("+= on a missing field must start from integer zero")
+				.script("{ $3 += 2; print $3 }")
+				.stdin("a\n")
+				.expectLines("2")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testUninitializedAccumulatorsStayExact() throws Exception {
+		AwkTestSupport
+				.awkTest("+= into an uninitialized variable must start from integer zero")
+				.script("BEGIN { s += 9007199254740992; s += 1; print s }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("+= into a missing array element must start from integer zero")
+				.script("BEGIN { a[1] += 9007199254740992; a[1] += 1; print a[1] }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+	}
+
+	@Test
 	public void testUnaryOperatorsStayExact() throws Exception {
 		AwkTestSupport
 				.awkTest("Unary minus must not round an exact integer")

--- a/src/test/java/io/jawk/ExactIntegerArithmeticTest.java
+++ b/src/test/java/io/jawk/ExactIntegerArithmeticTest.java
@@ -1,0 +1,204 @@
+package io.jawk;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.junit.Test;
+
+/**
+ * Tests that arithmetic on integral operands stays exact in 64 bits
+ * (<a href="https://github.com/jawkio/jawk/issues/537">#537</a>): results and
+ * comparisons beyond 2^53 keep all their digits, and results that do not fit
+ * in 64 bits fall back to floating point.
+ */
+public class ExactIntegerArithmeticTest {
+
+	@Test
+	public void testIntegralResultsStayExactBeyondDoublePrecision() throws Exception {
+		AwkTestSupport
+				.awkTest("Addition of integral operands must not round beyond 2^53")
+				.script("BEGIN { print 9007199254740992 + 1 }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Subtraction of integral operands must not round beyond 2^53")
+				.script("BEGIN { print 9007199254740994 - 1 }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Multiplication of integral operands must not round beyond 2^53")
+				.script("BEGIN { print 3002399751580331 * 3 }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("An even division of integral operands must stay exact")
+				.script("BEGIN { print 9223372036854775806 / 2 }")
+				.expectLines("4611686018427387903")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("A remainder of integral operands must stay exact")
+				.script("BEGIN { print 9223372036854775807 % 10 }")
+				.expectLines("7")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testCompoundAssignmentsAndSteppingStayExact() throws Exception {
+		AwkTestSupport
+				.awkTest("+= on a variable must stay exact beyond 2^53")
+				.script("BEGIN { x = 9007199254740992; x += 1; print x }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("++ on a variable must stay exact beyond 2^53")
+				.script("BEGIN { x = 9007199254740992; x++; print x }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("-- on a variable must stay exact beyond 2^53")
+				.script("BEGIN { x = 9007199254740994; x--; print x }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("+= on an array element must stay exact beyond 2^53")
+				.script("BEGIN { a[1] = 9007199254740992; a[1] += 1; print a[1] }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("++ on an array element must stay exact beyond 2^53")
+				.script("BEGIN { a[1] = 9007199254740992; a[1]++; print a[1] }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("An incremented counter must print as an integer")
+				.script("BEGIN { cnt[\"k\"]++; ++cnt[\"k\"]; printf \"%s\\n\", cnt[\"k\"] }")
+				.expectLines("2")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testUnaryOperatorsStayExact() throws Exception {
+		AwkTestSupport
+				.awkTest("Unary minus must not round an exact integer")
+				.script("BEGIN { x = 9007199254740993; print -x }")
+				.expectLines("-9007199254740993")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Unary plus must not round an exact integer")
+				.script("BEGIN { x = 9007199254740993; print +x }")
+				.expectLines("9007199254740993")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testComparisonsOfExactIntegersAreExact() throws Exception {
+		AwkTestSupport
+				.awkTest("Adjacent integers beyond 2^53 must compare as different")
+				.script("BEGIN { print (9007199254740993 == 9007199254740992) }")
+				.expectLines("0")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Ordering beyond 2^53 must be exact")
+				.script("BEGIN { print (9007199254740993 > 9007199254740992) }")
+				.expectLines("1")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testOverflowFallsBackToFloatingPoint() throws Exception {
+		AwkTestSupport
+				.awkTest("A sum beyond 64 bits must fall back to floating point")
+				.script("BEGIN { print 9223372036854775806 + 2 }")
+				.expectLines("9223372036854775808")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("A product beyond 64 bits must fall back to floating point")
+				.script("BEGIN { print 4611686018427387904 * 4 }")
+				.expectLines("18446744073709551616")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Negating the most negative 64-bit integer must fall back to floating point")
+				.script("BEGIN { x = -9223372036854775807 - 1; print -x }")
+				.expectLines("9223372036854775808")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testNonIntegralArithmeticIsUnchanged() throws Exception {
+		AwkTestSupport
+				.awkTest("A fractional quotient must stay floating point")
+				.script("BEGIN { print 5 / 2 }")
+				.expectLines("2.5")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("A remainder by zero must stay nan")
+				.script("BEGIN { print 5 % 0 }")
+				.expectLines("nan")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("A division by zero must stay inf")
+				.script("BEGIN { print 5 / 0 }")
+				.expectLines("inf")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Exponentiation stays in floating point")
+				.script("BEGIN { print 2 ^ 62 }")
+				.expectLines("4611686018427387904")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("Mixed integral and fractional operands compute in floating point")
+				.script("BEGIN { print 1 + 2.5 }")
+				.expectLines("3.5")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testConstantFoldingMatchesRuntimeSemantics() throws Exception {
+		// A fractional literal keeps double semantics whether the expression
+		// is folded at compile time (literals only) or evaluated at runtime
+		// (through a variable): folding must not gain exactness.
+		AwkTestSupport
+				.awkTest("A folded double addition must round exactly like the runtime one")
+				.script("BEGIN { print (9007199254740992.0 + 1 == 9007199254740993) }")
+				.expectLines("1")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("A runtime double addition rounds beyond 2^53")
+				.script("BEGIN { x = 9007199254740992.0; print (x + 1 == 9007199254740993) }")
+				.expectLines("1")
+				.runAndAssert();
+		AwkTestSupport
+				.awkTest("A folded integral addition must stay exact like the runtime one")
+				.script("BEGIN { x = 9007199254740992; y = x + 1; print (9007199254740992 + 1 == y) }")
+				.expectLines("1")
+				.runAndAssert();
+	}
+
+	@Test
+	public void testTightLoopAccumulationIsExact() throws Exception {
+		AwkTestSupport
+				.awkTest("A counting loop must accumulate exactly")
+				.script("BEGIN { s = 0; for (i = 0; i < 100000; i++) s = s + i; print s }")
+				.expectLines("4999950000")
+				.runAndAssert();
+	}
+}

--- a/src/test/java/io/jawk/JRTTest.java
+++ b/src/test/java/io/jawk/JRTTest.java
@@ -247,6 +247,58 @@ public class JRTTest {
 	}
 
 	@Test
+	public void testCompare2ExactIntegralOperands() {
+		// Two exact 64-bit integers compare exactly, without the precision
+		// loss a double conversion would introduce beyond 2^53.
+		assertFalse(JRT.compare2(9007199254740993L, 9007199254740992L, 0));
+		assertTrue(JRT.compare2(9007199254740993L, 9007199254740992L, 1));
+		assertTrue(JRT.compare2(9007199254740992L, 9007199254740993L, -1));
+		assertFalse(JRT.compare2(Long.MAX_VALUE, Long.MAX_VALUE - 1, 0));
+		assertTrue(JRT.compare2(Long.MAX_VALUE, Long.MAX_VALUE - 1, 1));
+		// Integer operands take the same exact path.
+		assertTrue(JRT.compare2(Integer.valueOf(3), 3L, 0));
+	}
+
+	@Test
+	public void testExactIntegralArithmetic() {
+		// Integral operands stay exact 64-bit integers.
+		assertEquals(Long.valueOf(3L), JRT.add(1L, 2L));
+		assertEquals(Long.valueOf(3L), JRT.add(Integer.valueOf(1), 2L));
+		assertEquals(Long.valueOf(9007199254740993L), JRT.add(9007199254740992L, 1L));
+		assertEquals(Long.valueOf(-1L), JRT.subtract(1L, 2L));
+		assertEquals(Long.valueOf(9007199254740991L), JRT.subtract(9007199254740992L, 1L));
+		assertEquals(Long.valueOf(6L), JRT.multiply(2L, 3L));
+		assertEquals(Long.valueOf(4611686018427387903L), JRT.divide(9223372036854775806L, 2L));
+		assertEquals(Long.valueOf(7L), JRT.mod(Long.MAX_VALUE, 10L));
+		assertEquals(Long.valueOf(-9007199254740993L), JRT.negate(9007199254740993L));
+		assertEquals(Long.valueOf(9007199254740993L), JRT.inc(9007199254740992L));
+		assertEquals(Long.valueOf(9007199254740991L), JRT.dec(9007199254740992L));
+	}
+
+	@Test
+	public void testExactIntegralArithmeticOverflowFallsBackToDouble() {
+		assertEquals(9.223372036854776E18, ((Number) JRT.add(Long.MAX_VALUE, 1L)).doubleValue(), 0);
+		assertEquals(-9.223372036854776E18, ((Number) JRT.subtract(Long.MIN_VALUE, 1L)).doubleValue(), 0);
+		assertEquals(1.8446744073709552E19, ((Number) JRT.multiply(Long.MAX_VALUE, 2L)).doubleValue(), 0);
+		assertEquals(9.223372036854776E18, ((Number) JRT.divide(Long.MIN_VALUE, -1L)).doubleValue(), 0);
+		assertEquals(9.223372036854776E18, ((Number) JRT.inc(Long.MAX_VALUE)).doubleValue(), 0);
+		assertEquals(-9.223372036854776E18, ((Number) JRT.dec(Long.MIN_VALUE)).doubleValue(), 0);
+		assertEquals(9.223372036854776E18, ((Number) JRT.negate(Long.MIN_VALUE)).doubleValue(), 0);
+	}
+
+	@Test
+	public void testNonIntegralArithmeticStaysInFloatingPoint() {
+		// A fractional quotient, a zero divisor, or any non-integral operand
+		// computes in floating point, exactly as before.
+		assertEquals(Double.valueOf(2.5), JRT.divide(5L, 2L));
+		assertEquals(Double.valueOf(4.0), JRT.add(1.5, 2.5));
+		assertEquals(Double.valueOf(3.0), JRT.add("1", 2L));
+		assertTrue(Double.isNaN(((Number) JRT.mod(5L, 0L)).doubleValue()));
+		assertTrue(Double.isInfinite(((Number) JRT.divide(5L, 0L)).doubleValue()));
+		assertEquals(Double.valueOf(8.0), JRT.pow(2L, 3L));
+	}
+
+	@Test
 	public void testCompare2PlainStrings() {
 		assertFalse(JRT.compare2("3", "3.0", 0));
 		assertTrue(JRT.compare2("3", "4.0", -1));


### PR DESCRIPTION
Implements directions 1 and 2 of #537: arithmetic and comparison hot paths keep exact integral results as `Long` instead of re-boxing a fresh `Double` on every operation.

## What

- **`JRT` now owns the operator semantics as helpers** (`add`, `subtract`, `multiply`, `divide`, `mod`, `pow`, `negate`, plus exact `inc`/`dec`): when both operands are exact 64-bit integers (`Long`/`Integer`) and the result fits in 64 bits, the result stays an exact `Long` (boxed through `Long.valueOf`, so values in −128..127 hit the JDK box cache); anything else falls back to the previous double arithmetic. `/` stays exact only for an evenly-dividing quotient, `%` for a non-zero divisor, and `^` always computes in floating point like gawk.
- **`compare2` compares two exact integers as longs**, skipping the double conversion (and its precision loss beyond 2^53).
- **`AVM` routes `ADD`…`POW`, `NEGATE`, `UNARY_PLUS`, the compound-assignment families (variables, array elements, map elements, and input fields), and every `++`/`--` opcode through those helpers.** `UNARY_PLUS` pushes a numeric scalar back unchanged instead of re-boxing it, and a compound assignment or `++`/`--` on an uninitialized variable, missing array element, or missing field starts from integer zero, so counters built that way stay exact (`$1 = 9007199254740992; $1 += 1` prints `9007199254740993`). A field updated with `+=`/`++` retains the numeric scalar itself (like `$1 = expr` always did), so repeated updates stay exact; reconstituting `$0` converts numeric field values with `CONVFMT` as POSIX requires and gawk does (`{ $1 = 0.1 + 0.2; print }` prints `0.3 ...`, previously the raw `0.30000000000000004 ...`), while `$0` itself remains record text and converts immediately.
- **Constant folding (`AwkTuples`) folds through the same helpers and keeps their exact result type.** Normalizing an integral `Double` fold result to `Long` (as the old folder did) would now give folded literal chains an exactness the equivalent runtime evaluation does not have, so the folder returns exactly what the interpreter would compute; a regression test pins fold-vs-runtime consistency. The intermediate `serialVersionUID` is bumped to 5 so precompiled programs carrying constants folded in floating point are recompiled.

## Behavior change (documented)

Arithmetic on integral operands is now exact in 64 bits, extending the exactness Jawk already guarantees for 64-bit literals, `%d` formatting, and array subscripts to the operators themselves (`behavior-changes.md` + a new `compatibility.md.vm` section):

- `print 9007199254740992 + 1` prints `9007199254740993` where default gawk (C doubles, verified against gawk 5.0) prints `9007199254740992`; comparisons between two exact integers are exact as well.
- Overflow falls back to floating point (`print 9223372036854775806 + 2` → `9223372036854775808`); fractional/string operands are unchanged.
- Integer results carry no negative zero: with `x = 0`, `1/-x` prints `inf` (previously `-inf`; gawk fatals on any division by zero, which Jawk deliberately does not).

## Verification

- `mvn verify` green: 752 unit tests, checkstyle/pmd/spotbugs clean (the 11 pmd hits are pre-existing in untouched files).
- Compat suite compared against a `main` baseline run: **zero regressions, and the CONVFMT record-rebuild fix turns two previously failing BWK fixtures green** (`t.set0`, `t.set3`) — 147 known failures vs main's 149.

## Measurement (JMH, Windows 11, `-f 2 -wi 2 -i 3` defaults)

`AwkScriptBenchmark.tightArithmeticLoop` is added by this PR (`BEGIN { s=0; for (i=0; i<50000; i++) s=s+i; print s }`).

| Benchmark | before | after |
|---|---|---|
| tightArithmeticLoop (µs/op) | 63 866 ± 3 286 | 66 069 ± 16 735 |
| sumInputValues (µs/op) | 16.80 ± 3.93 | 16.62 ± 1.69 |
| projectMatchingValues (µs/op) | 19.67 ± 1.82 | 19.91 ± 1.48 |
| literalAddition (ns/op) | 197.4 ± 14.3 | 213.0 ± 19.0 |
| fieldAddition (ns/op) | 425.2 ± 28.6 | 414.6 ± 34.2 |
| fieldMultiplication (ns/op) | 419.2 ± 23.0 | 416.4 ± 54.0 |

**Honest read: performance parity — every delta is within the error bars** (a higher-fork rerun was attempted but ambient load on the benchmark machine made it unusable; the paired runs above were taken on a quiet machine). This matches the issue's own expectation: a `Long` box costs the same as a `Double` box, so swapping the box type alone cannot cut the allocation count — the churn is dominated by the operand stack (#536), and the allocation-free win is the direction-3 dual-stack/tagged-accumulator design, for which the `JRT` helpers introduced here are the necessary seam. What this PR does deliver now is the exactness/fidelity improvement (direction 1) and the small-integer box cache (direction 2), with no measured cost.

Benchmarks should be re-run once #536 lands, as the issue notes.

Fixes #537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
